### PR TITLE
Dedicated label matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,31 @@ tRanker, err = New(
     }, &dummyTaskRankReceiver{}))
 ```
 
+##### Dedicated Label Matchers
+The existing [cpushares task ranking strategy](./strategies/taskRankCpuSharesStrategy.go) only uses `cpushares`
+specification to rank currently running tasks. However, certain task ranking strategies could rank tasks based
+on dynamically changing metrics such as cpu usage, memory usage etc. Such strategies would therefore need to be
+able to map data pulled from prometheus to currently running tasks.
+
+Dedicated Label Matchers can be used for this purpose. A dedicated label matcher is one that the strategy is aware of
+and can use to filter data from prometheus when calibrating each running task.
+
+Currently, the following dedicated label matchers are supported.
+1. [TaskID](./query/label.go) - This is used to flag a label as one that can be used to fetch the unique identifier of
+    a task.
+2. [TaskHostname](./query/label.go) - This is used to flag a label as one that can be used to fetch the name of the
+    host on which the task is running.
+    
+Dedicated label matchers will need to be provided when using strategies that demand them.
+The below code snippet shows how a dedicated label can be provided when configuring the Task Ranker.
+
+```go
+WithStrategy("test-strategy", []*query.LabelMatcher{
+    {Type: query.TaskID, Label: "taskid_label", Operator: query.NotEqual, Value: ""},
+    ... // Other label matchers.
+})
+```
+
 #### Start the Task Ranker
 Once the Task Ranker has been configured, then you can start it by calling `tRanker.Start()`.
 

--- a/query/builder.go
+++ b/query/builder.go
@@ -29,7 +29,7 @@ type Builder struct {
 	// The unit of time to use when performing range queries. This is an optional field.
 	// If this field is not initialized, then
 	timeUnit     TimeUnit
-	timeDuration int
+	timeDuration uint
 	// TODO (pkaushi1) support functions.
 }
 
@@ -81,7 +81,7 @@ func WithLabelMatchers(labelMatchers ...*LabelMatcher) Option {
 
 // WithRange returns an option that initializes the time unit and the duration when
 // performing range queries.
-func WithRange(timeUnit TimeUnit, durationQty int) Option {
+func WithRange(timeUnit TimeUnit, durationQty uint) Option {
 	return func(b *Builder) {
 		b.timeUnit = timeUnit
 		b.timeDuration = durationQty

--- a/query/builder_test.go
+++ b/query/builder_test.go
@@ -55,7 +55,7 @@ func TestGetBuilder(t *testing.T) {
 		Value:    "test_value2",
 	}, testBuilder.labelMatchers[1])
 	assert.Equal(t, Seconds, testBuilder.timeUnit)
-	assert.Equal(t, 5, testBuilder.timeDuration)
+	assert.Equal(t, uint(5), testBuilder.timeDuration)
 }
 
 func TestBuilder_BuildQuery(t *testing.T) {

--- a/ranker.go
+++ b/ranker.go
@@ -82,7 +82,10 @@ func WithStrategy(
 			return err
 		} else {
 			tRanker.Strategy = s
-			strategies.Build(tRanker.Strategy, labelMatchers, receiver)
+			err := strategies.Build(tRanker.Strategy, labelMatchers, receiver)
+			if err != nil {
+				return errors.Wrap(err, "failed to build strategy")
+			}
 			tRanker.DataFetcher.SetStrategy(s)
 		}
 		return nil

--- a/strategies/strategy.go
+++ b/strategies/strategy.go
@@ -36,7 +36,7 @@ type Interface interface {
 	GetLabelMatchers() []*query.LabelMatcher
 	// Range returns the duration specifying how far back in time data needs to be fetched.
 	// Returns the unit of time along with an integer quantifying the duration.
-	GetRange() (query.TimeUnit, int)
+	GetRange() (query.TimeUnit, uint)
 }
 
 // Build the strategy object.

--- a/strategies/strategy.go
+++ b/strategies/strategy.go
@@ -15,6 +15,7 @@
 package strategies
 
 import (
+	"github.com/pkg/errors"
 	"github.com/pradykaushik/task-ranker/query"
 	"github.com/prometheus/common/model"
 )
@@ -30,7 +31,8 @@ type Interface interface {
 	// Note: This has to be a single metric name.
 	GetMetric() string
 	// SetLabelMatchers sets the label matchers to use to filter data.
-	SetLabelMatchers([]*query.LabelMatcher)
+	// Strategy implementations can perform additional validations on the provided label matchers.
+	SetLabelMatchers([]*query.LabelMatcher) error
 	// GetLabelMatchers returns the labels and corresponding matching operators to use
 	// filter out data that is not required by this strategy.
 	GetLabelMatchers() []*query.LabelMatcher
@@ -40,7 +42,14 @@ type Interface interface {
 }
 
 // Build the strategy object.
-func Build(s Interface, labelMatchers []*query.LabelMatcher, receiver TaskRanksReceiver) {
+func Build(s Interface, labelMatchers []*query.LabelMatcher, receiver TaskRanksReceiver) error {
+	if receiver == nil {
+		return errors.New("nil receiver provided")
+	}
+
 	s.SetTaskRanksReceiver(receiver)
-	s.SetLabelMatchers(labelMatchers)
+	if err := s.SetLabelMatchers(labelMatchers); err != nil {
+		return errors.Wrap(err, "invalid label matchers for strategy")
+	}
+	return nil
 }

--- a/strategies/taskRankCpuSharesStrategy.go
+++ b/strategies/taskRankCpuSharesStrategy.go
@@ -98,6 +98,6 @@ func (s TaskRankCpuSharesStrategy) GetLabelMatchers() []*query.LabelMatcher {
 }
 
 // GetRange returns the time unit and duration for how far back values need to be fetched.
-func (s TaskRankCpuSharesStrategy) GetRange() (query.TimeUnit, int) {
+func (s TaskRankCpuSharesStrategy) GetRange() (query.TimeUnit, uint) {
 	return query.Seconds, 5
 }

--- a/strategies/taskRankCpuSharesStrategy.go
+++ b/strategies/taskRankCpuSharesStrategy.go
@@ -15,6 +15,7 @@
 package strategies
 
 import (
+	"github.com/pkg/errors"
 	"github.com/pradykaushik/task-ranker/entities"
 	"github.com/pradykaushik/task-ranker/query"
 	"github.com/prometheus/common/model"
@@ -78,7 +79,7 @@ func (s TaskRankCpuSharesStrategy) avgCpuShare(values []model.SamplePair) float6
 	for _, val := range values {
 		sum += float64(val.Value)
 	}
-	return sum/float64(len(values))
+	return sum / float64(len(values))
 }
 
 // GetMetric returns the name of the metric to query.
@@ -88,8 +89,12 @@ func (s TaskRankCpuSharesStrategy) GetMetric() string {
 }
 
 // SetLabelMatchers sets the label matchers to use to filter data.
-func (s *TaskRankCpuSharesStrategy) SetLabelMatchers(labelMatchers []*query.LabelMatcher) {
+func (s *TaskRankCpuSharesStrategy) SetLabelMatchers(labelMatchers []*query.LabelMatcher) error {
+	if len(labelMatchers) == 0 {
+		return errors.New("no label matchers provided")
+	}
 	s.labels = labelMatchers
+	return nil
 }
 
 // GetLabelMatchers returns the label matchers to be used to filter data.


### PR DESCRIPTION
Added dedicated label matchers that can be used filter prometheus data
based on a task's unique identifier and/or name of the host on which
a task is running.
Strategies can mandate the use of dedicated label matchers, especially
if tasks' runtime information is used for ranking.
LabelMatcher not contains a type that can be set to one of the following.
1. Other (default).
2. TaskID - flag label as one that can be used to fetch unique identifier
	of task.
3. TaskHostname - flag labe as one that can be used to fetch name of host
	on which task is running.

Updated README to include instructions on providing dedicated labels.