### PR TITLE
receiver and strategy API change + resource intensity based ranking

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ resource isolation and usage information of running containers.
 See [cAdvisor docs](https://github.com/google/cadvisor/blob/master/docs/storage/prometheus.md)
 for more information on how to monitor cAdvisor with Prometheus.
 
-##### Container Label Prefixes
+#### Container Label Prefixes
 CAdvisor [prefixes all container labels with `container_label_`](https://github.com/google/cadvisor/blob/1223982cc4f575354f28f631a3bd00be88ba2f9f/metrics/prometheus.go#L1633).
 Given that the Task Ranker only talks to Prometheus, the labels provided should also include these prefixes.
 For example, let us say that we launch a task in a docker container using the command below.

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ Rank tasks running as docker containers in a cluster.
 
 Task Ranker runs as a cron job on a specified schedule. Each time the task ranker is run,
 it fetches data from [Prometheus](https://prometheus.io/), filters the data as required and then
-submits it to a ranking strategy. The task ranking strategy uses the data received to
+submits it to a task ranking strategy. The task ranking strategy uses the data received to
 calibrate currently running tasks on the cluster and then rank them accordingly. The results
 of the strategy are then fed back to the user through callbacks.
 
-You will need to have a [working Golang environment running at least 1.12](https://golang.org/dl/).
+You will need to have a [working Golang environment running at least 1.12](https://golang.org/dl/) and a Linux environment.
 
 ### How To Use?
 Run the below command to download and install Task Ranker.
@@ -25,7 +25,16 @@ resource isolation and usage information of running containers.
 See [cAdvisor docs](https://github.com/google/cadvisor/blob/master/docs/storage/prometheus.md)
 for more information on how to monitor cAdvisor with Prometheus.
 
-#### Configure
+##### Container Label Prefixes
+CAdvisor [prefixes all container labels with `container_label_`](https://github.com/google/cadvisor/blob/1223982cc4f575354f28f631a3bd00be88ba2f9f/metrics/prometheus.go#L1633).
+Given that the Task Ranker only talks to Prometheus, the labels provided should also include these prefixes.
+For example, let us say that we launch a task in a docker container using the command below.
+```commandline
+docker run --label task_id="1234" -t repository/name:version
+```
+CAdvisor would then export `container_label_task_id` as the container label.
+
+#### Configuration
 Task Ranker configuration requires two components to be configured and provided.
 1. DataFetcher - Responsible for fetching data from Prometheus, filtering it
     using the provided labels and submitting it to the chosen strategy.
@@ -35,10 +44,19 @@ Task Ranker configuration requires two components to be configured and provided.
     - Receiver of the task ranking results.
 
 Task Ranker is configured as shown below.
+The below code snippet shows how Task Ranker can be configured to,
+* fetch time series data from a Prometheus server running at [http://localhost:9090](http://localhost:9090).
+* data is fetched every 5 seconds.
+* use the [cpushares](./strategies/taskRankCpuSharesStrategy.go) strategy to rank tasks.
+* filter out metrics where `container_label_task_id!=""`.
+* filter out metrics where `container_label_task_host!=""`.
+* use `container_label_task_id` as the [dedicated label](#dedicated-label-matchers) to help retrieve the task identifier.
+* use `container_label_task_host` as the [dedicated label](#dedicated-label-matchers) to help retrieve the hostname on which the task is running.
+* use `dummyTaskRanksReceiver` as the receiver of ranked tasks.
 ```go
-type dummyTaskRankReceiver struct{}
+type dummyTaskRanksReceiver struct{}
 
-func (r *dummyTaskRankReceiver) Receive(rankedTasks []entities.Task) {
+func (r *dummyTaskRanksReceiver) Receive(rankedTasks entities.RankedTasks) {
 	log.Println(rankedTasks)
 }
 
@@ -49,29 +67,14 @@ tRanker, err = New(
     WithDataFetcher(prometheusDataFetcher),
     WithSchedule("?/5 * * * * *"),
     WithStrategy("cpushares", []*query.LabelMatcher{
-        {Label: "label1", Operator: query.NotEqual, Value: ""},
-        {Label: "label2", Operator: query.NotEqual, Value: ""},
-    }, &dummyTaskRankReceiver{}))
+        {Type: query.TaskID, Label: "container_label_task_id", Operator: query.NotEqual, Value: ""},
+        {Type: query.TaskHostname, Label: "container_label_task_host", Operator: query.Equal, Value: "localhost"},
+    }, &dummyTaskRanksReceiver{}))
 ```
-
-##### Container Label Prefixes
-CAdvisor [prefixes all container labels with `container_label_`](https://github.com/google/cadvisor/blob/1223982cc4f575354f28f631a3bd00be88ba2f9f/metrics/prometheus.go#L1633).
-Given that the Task Ranker only talks to Prometheus, the labels provided should also include these prefixes.
-
-For example, let us say that we launch a task in a docker container using the command below.
-```commandline
-docker run --label task_id="1234" -t repository/name:version
-```
-CAdvisor would then export `container_label_task_id` as the container label.
 
 ##### Dedicated Label Matchers
-The existing [cpushares task ranking strategy](./strategies/taskRankCpuSharesStrategy.go) only uses `cpushares`
-specification to rank currently running tasks. However, certain task ranking strategies could rank tasks based
-on dynamically changing metrics such as cpu usage, memory usage etc. Such strategies would therefore need to be
-able to map data pulled from prometheus to currently running tasks.
-
-Dedicated Label Matchers can be used for this purpose. A dedicated label matcher is one that the strategy is aware of
-and can use to filter data from prometheus when calibrating each running task.
+Dedicated Label Matchers can be used to retrieve the task ID and host information from data retrieved
+from Prometheus. Strategies can mandate the requirement for one or more dedicated labels.
 
 Currently, the following dedicated label matchers are supported.
 1. [TaskID](./query/label.go) - This is used to flag a label as one that can be used to fetch the unique identifier of
@@ -79,11 +82,15 @@ Currently, the following dedicated label matchers are supported.
 2. [TaskHostname](./query/label.go) - This is used to flag a label as one that can be used to fetch the name of the
     host on which the task is running.
     
-Dedicated label matchers will need to be provided when using strategies that demand them.
+Strategies can demand that one or more dedicated labels be provided. For instance, if a strategy
+ranks all tasks running on the cluster, then it can mandate only **_TaskID_** dedicated label. On the other
+hand if a strategy ranks colocated tasks, then it can mandate both **_TaskID_** and **_TaskHostname_** dedicated labels.
+
+Dedicated label matchers will need to be provided when using strategies that demand them.<br>
 The below code snippet shows how a dedicated label can be provided when configuring the Task Ranker.
 
 ```go
-WithStrategy("test-strategy", []*query.LabelMatcher{
+WithStrategy("strategy-name", []*query.LabelMatcher{
     {Type: query.TaskID, Label: "taskid_label", Operator: query.NotEqual, Value: ""},
     ... // Other label matchers.
 })
@@ -93,32 +100,35 @@ WithStrategy("test-strategy", []*query.LabelMatcher{
 Once the Task Ranker has been configured, then you can start it by calling `tRanker.Start()`.
 
 ### Test Locally
-Run `docker-compose up` to bring up a docker-compose installation running Prometheus and cAdvisor.
+#### Setup
+Run [`./create_test_env`](./create_test_env) to,
+1. bring up a docker-compose installation running Prometheus and cAdvisor.
+2. run [tasks](taskdockerfile) in docker containers.
+
+Each container is allocated different cpu-shares.
 For more information on running Prometheus and cAdvisor locally see [here](https://prometheus.io/docs/guides/cadvisor/#monitoring-docker-container-metrics-using-cadvisor).
 
-Once you have Prometheus and cAdvisor running (test by running `curl http://localhost:9090/metrics` or using the browser),
-run the below command to launch three containers to simulate to tasks.
+Once you have Prometheus and cAdvisor running (test by running `curl http://localhost:9090/metrics` or use the browser),
 
-```commandline
-docker run --name test_container_1 --label task_name="test_task_ubuntu_1" --cpu-shares 1024 -it ubuntu:latest /bin/bash
-docker run --name test_container_2 --label task_name="test_task_ubuntu_2" --cpu-shares 2048 -it ubuntu:latest /bin/bash
-docker run --name test_container_3 --label task_name="test_task_ubuntu_3" --cpu-shares 3072 -it ubuntu:latest /bin/bash
-```
-Each container is allocated different cpu-shares to ease the verification of task ranking results.
-
+#### Test
 Now run the below command to run tests.
 ```commandline
 go test -v ./...
 ```
 
-The task ranking results are displayed on the console. Below is what it will look like.
+The task ranking results are displayed on the console.
+Below is what it will look like.
 ```commandline
-Metric: container_spec_cpu_shares{container_label_task_name="test_task_ubuntu_3", id="/docker/<container_id>", image="ubuntu:latest", instance="cadvisor:8080", job="cadvisor", name="test_container_3"}
-Weight: 3072.000000
-
-Metric: container_spec_cpu_shares{container_label_task_name="test_task_ubuntu_2", id="/docker/<container_id>", image="ubuntu:latest", instance="cadvisor:8080", job="cadvisor", name="test_container_2"}
-Weight: 2048.000000
-
-Metric: container_spec_cpu_shares{container_label_task_name="test_task_ubuntu_1", id="/docker/<container_id>", image="ubuntu:latest", instance="cadvisor:8080", job="cadvisor", name="test_container_1"}
-Weight: 1024.000000
+HOST = localhost
+========================================================================
+		
+[TaskID = <task id>,Hostname = localhost,Weight = <weight>,], Rank = 0
+[TaskID = <task id>,Hostname = localhost,Weight = <weight>,], Rank = 1
+[TaskID = <task id>,Hostname = localhost,Weight = <weight>,], Rank = 2
+...
+[TaskID = <task id>,Hostname = localhost,Weight = <weight>,], Rank = n
+========================================================================
 ```
+
+#### Tear-Down
+Once finished testing, tear down the test environment by running [`./tear_down_test_env`](./tear_down_test_env).

--- a/create_test_env
+++ b/create_test_env
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Launching cAdvisor and prometheus using docker compose.
+docker-compose up -d
+
+# Running tasks.
+for i in {1..3}; do
+  cpushares=$(expr $i \* 1024)
+  docker run -d --name test_hello_"$i" --label task_id="hello_${i}" --label task_host="localhost" --cpu-shares $cpushares -it taskranker/hello:latest
+done

--- a/entities/task.go
+++ b/entities/task.go
@@ -18,26 +18,68 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/prometheus/common/model"
+	"strings"
 )
 
-type RankedTask struct {
+type Hostname string
+type RankedTasks map[Hostname][]Task
+
+// String returns a beautified string representation of ranked tasks.
+func (rankedTasks RankedTasks) String() string {
+	var buf bytes.Buffer
+	const delimiter = "========================================================================"
+
+	for hostname, rankedColocatedTasks := range rankedTasks {
+		var info []string
+		info = append(info, fmt.Sprintf("HOST = %s", hostname))
+		info = append(info, delimiter)
+		info = append(info, "\t\t")
+		for rank, task := range rankedColocatedTasks {
+			info = append(info, fmt.Sprintf("%v, Rank = %d", task, rank))
+		}
+		info = append(info, delimiter)
+		buf.WriteString(strings.Join(info, "\n"))
+	}
+	return buf.String()
+}
+
+type Task struct {
+	// TODO decide whether we can get rid of this field.
 	Metric model.Metric
+	// Weight assigned to the task that was the ranking criteria.
 	Weight float64
+	// ID represents the unique identifier for the task (Optional).
+	ID string
+	// Hostname represents the name of the host on which the task was scheduled (Optional).
+	Hostname string
 }
 
 // GetMetric returns the metric as returned by the query.
-func (t RankedTask) GetMetric() model.Metric {
+func (t Task) GetMetric() model.Metric {
 	return t.Metric
 }
 
 // GetWeight returns the weight assigned to the task as a result of calibration.
-func (t RankedTask) GetWeight() float64 {
+func (t Task) GetWeight() float64 {
 	return t.Weight
 }
 
-func (t RankedTask) String() string {
+// GetTaskID returns the task identifier.
+func (t Task) GetTaskID() string {
+	return t.ID
+}
+
+// GetHostname returns the name of the host on which the task was scheduled.
+func (t Task) GetHostname() string {
+	return t.Hostname
+}
+
+func (t Task) String() string {
 	var buf bytes.Buffer
-	buf.WriteString(fmt.Sprintf("Metric: %v\n", t.Metric))
-	buf.WriteString(fmt.Sprintf("Weight: %f\n", t.Weight))
+	buf.WriteString("[")
+	buf.WriteString(fmt.Sprintf("TaskID = %s,", t.ID))
+	buf.WriteString(fmt.Sprintf("Hostname = %s,", t.Hostname))
+	buf.WriteString(fmt.Sprintf("Weight = %f,", t.Weight))
+	buf.WriteString("]")
 	return buf.String()
 }

--- a/query/builder.go
+++ b/query/builder.go
@@ -33,17 +33,11 @@ type Builder struct {
 	// TODO (pkaushi1) support functions.
 }
 
-// Singleton builder instance.
-var builderInstance *Builder
-
-// GetBuilder instantiates the singleton Builder instance if required
-// and then returns it.
-func GetBuilder(options ...Option) *Builder {
-	if builderInstance == nil {
-		builderInstance = new(Builder)
-		for _, opt := range options {
-			opt(builderInstance)
-		}
+// NewBuilder returns a new Builder by applying all the given options.
+func NewBuilder(options ...Option) *Builder {
+	builderInstance := new(Builder)
+	for _, opt := range options {
+		opt(builderInstance)
 	}
 
 	return builderInstance

--- a/query/builder_test.go
+++ b/query/builder_test.go
@@ -40,7 +40,7 @@ func TestMain(m *testing.M) {
 	m.Run()
 }
 
-func TestGetBuilder(t *testing.T) {
+func TestNewBuilder(t *testing.T) {
 	assert.NotNil(t, testBuilder)
 	assert.Equal(t, "test_metric", testBuilder.metric)
 	assert.Len(t, testBuilder.labelMatchers, 2)

--- a/query/builder_test.go
+++ b/query/builder_test.go
@@ -22,7 +22,7 @@ import (
 var testBuilder *Builder
 
 func TestMain(m *testing.M) {
-	testBuilder = GetBuilder(
+	testBuilder = NewBuilder(
 		WithMetric("test_metric"),
 		WithLabelMatchers(
 			&LabelMatcher{

--- a/ranker.go
+++ b/ranker.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pradykaushik/task-ranker/util"
 	"github.com/robfig/cron/v3"
 	"log"
+	"time"
 )
 
 // TaskRanker fetches data pertaining to currently running tasks, deploys a strategy
@@ -70,7 +71,8 @@ func WithDataFetcher(dataFetcher df.Interface) Option {
 func WithStrategy(
 	strategy string,
 	labelMatchers []*query.LabelMatcher,
-	receiver strategies.TaskRanksReceiver) Option {
+	receiver strategies.TaskRanksReceiver,
+	prometheusScrapeInterval time.Duration) Option {
 
 	return func(tRanker *TaskRanker) error {
 		if strategy == "" {
@@ -82,7 +84,7 @@ func WithStrategy(
 			return err
 		} else {
 			tRanker.Strategy = s
-			err := strategies.Build(tRanker.Strategy, labelMatchers, receiver)
+			err := strategies.Build(tRanker.Strategy, labelMatchers, receiver, prometheusScrapeInterval)
 			if err != nil {
 				return errors.Wrap(err, "failed to build strategy")
 			}

--- a/ranker_e2e_test.go
+++ b/ranker_e2e_test.go
@@ -55,9 +55,14 @@ func initTaskRanker(strategy string) (*TaskRanker, error) {
 	return tRanker, err
 }
 
-// Test the cpushares task ranking strategy by fetching data from a local prometheus + cAdvisor setup.
+// Test the cpushares task ranking strategy.
 func TestTaskRanker_CpuSharesRanking(t *testing.T) {
 	testStrategy(t, "cpushares")
+}
+
+// Test the cpuutil task ranking strategy.
+func TestTaskRanker_CpuUtilRanking(t *testing.T) {
+	testStrategy(t, "cpuutil")
 }
 
 func testStrategy(t *testing.T, strategy string) {

--- a/ranker_e2e_test.go
+++ b/ranker_e2e_test.go
@@ -1,0 +1,87 @@
+// Copyright 2020 Pradyumna Kaushik
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package taskranker
+
+import (
+	"fmt"
+	"github.com/pradykaushik/task-ranker/datafetcher"
+	"github.com/pradykaushik/task-ranker/datafetcher/prometheus"
+	"github.com/pradykaushik/task-ranker/entities"
+	"github.com/pradykaushik/task-ranker/query"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+type dummyTaskRanksReceiver struct {
+	rankedTasks entities.RankedTasks
+}
+
+func (r *dummyTaskRanksReceiver) Receive(rankedTasks entities.RankedTasks) {
+	r.rankedTasks = rankedTasks
+	fmt.Println(rankedTasks)
+}
+
+var dummyReceiver *dummyTaskRanksReceiver
+
+func initTaskRanker(strategy string) (*TaskRanker, error) {
+	var prometheusDataFetcher datafetcher.Interface
+	var err error
+	var tRanker *TaskRanker
+
+	prometheusDataFetcher, err = prometheus.NewDataFetcher(
+		prometheus.WithPrometheusEndpoint("http://localhost:9090"))
+
+	dummyReceiver = new(dummyTaskRanksReceiver)
+	tRanker, err = New(
+		WithDataFetcher(prometheusDataFetcher),
+		WithSchedule("?/5 * * * * *"),
+		WithStrategy(strategy, []*query.LabelMatcher{
+			{Type: query.TaskID, Label: "container_label_task_id", Operator: query.EqualRegex, Value: "hello_.*"},
+			{Type: query.TaskHostname, Label: "container_label_task_host", Operator: query.Equal, Value: "localhost"},
+		}, dummyReceiver, 1*time.Second))
+
+	return tRanker, err
+}
+
+// Test the cpushares task ranking strategy by fetching data from a local prometheus + cAdvisor setup.
+func TestTaskRanker_CpuSharesRanking(t *testing.T) {
+	testStrategy(t, "cpushares")
+}
+
+func testStrategy(t *testing.T, strategy string) {
+	tRanker, initErr := initTaskRanker(strategy)
+	assert.NoError(t, initErr)
+	assert.NotNil(t, tRanker)
+	tRanker.Start()
+	<-time.After(7 * time.Second) // Enough time for one round of ranking.
+	testRanked(t)
+	tRanker.Stop()
+}
+
+func testRanked(t *testing.T) {
+	for hostname, rankedColocatedTasks := range dummyReceiver.rankedTasks {
+		assert.NotEmpty(t, hostname)
+		assert.NotNil(t, rankedColocatedTasks)
+		assert.NotEmpty(t, rankedColocatedTasks)
+
+		var prevTask = rankedColocatedTasks[0]
+		for i := 1; i < len(rankedColocatedTasks); i++ {
+			assert.Equal(t, prevTask.Hostname, "localhost")
+			assert.Contains(t, prevTask.ID, "hello_")
+			assert.True(t, prevTask.Weight >= rankedColocatedTasks[i].Weight)
+			prevTask = rankedColocatedTasks[i]
+		}
+	}
+}

--- a/ranker_test.go
+++ b/ranker_test.go
@@ -15,93 +15,28 @@
 package taskranker
 
 import (
-	"bytes"
-	"fmt"
-	"github.com/pradykaushik/task-ranker/datafetcher"
 	"github.com/pradykaushik/task-ranker/datafetcher/prometheus"
-	"github.com/pradykaushik/task-ranker/entities"
 	"github.com/pradykaushik/task-ranker/query"
 	"github.com/pradykaushik/task-ranker/strategies"
 	"github.com/robfig/cron/v3"
 	"github.com/stretchr/testify/assert"
-	"log"
 	"testing"
-	"time"
 )
 
-type dummyTaskRankReceiver struct{}
-
-func (r *dummyTaskRankReceiver) Receive(rankedTasks []entities.RankedTask) {
-	var buf bytes.Buffer
-	for _, t := range rankedTasks {
-		buf.WriteString(fmt.Sprintf("%v\n", t.String()))
-	}
-	log.Println(buf.String())
-}
-
-func initTaskRanker(t *testing.T) (*TaskRanker, error) {
-	var err error
-	var prometheusDataFetcher datafetcher.Interface
-	var tRanker *TaskRanker
-
-	prometheusDataFetcher, err = prometheus.NewDataFetcher(
-		prometheus.WithPrometheusEndpoint("http://localhost:9090"))
-
-	assert.NoError(t, err)
-	assert.NotNil(t, prometheusDataFetcher)
-
-	tRanker, err = New(
-		WithDataFetcher(prometheusDataFetcher),
-		WithSchedule("?/5 * * * * *"),
-		WithStrategy("cpushares", []*query.LabelMatcher{
-			{Label: "label1", Operator: query.Equal},
-			{Label: "label2", Operator: query.Equal},
-		}, &dummyTaskRankReceiver{}))
-
-	return tRanker, err
-}
-
 func TestNew(t *testing.T) {
-	var err error
-	var tRanker *TaskRanker
-	tRanker, err = initTaskRanker(t)
-	assert.NoError(t, err)
+	tRanker, initErr := initTaskRanker("cpushares")
+	assert.NoError(t, initErr)
 	assert.NotNil(t, tRanker)
 	assert.NotNil(t, tRanker.DataFetcher)
 	assert.NotNil(t, tRanker.Strategy)
 	assert.Equal(t, "http://localhost:9090",
 		tRanker.DataFetcher.(*prometheus.DataFetcher).GetEndpoint())
 	assert.ElementsMatch(t, []*query.LabelMatcher{
-		{Label: "label1", Operator: query.Equal},
-		{Label: "label2", Operator: query.Equal},
+		{Type: query.TaskID, Label: "container_label_task_id", Operator: query.EqualRegex, Value: "hello_.*"},
+		{Type: query.TaskHostname, Label: "container_label_task_host", Operator: query.Equal, Value: "localhost"},
 	}, tRanker.Strategy.(*strategies.TaskRankCpuSharesStrategy).GetLabelMatchers())
 	parser := cron.NewParser(cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
-	var sched cron.Schedule
-	sched, err = parser.Parse("?/5 * * * * *")
+	tRankerSchedule, err := parser.Parse("?/5 * * * * *")
 	assert.NoError(t, err)
-	assert.Equal(t, sched, tRanker.Schedule)
-}
-
-// Test the cpushares task ranking strategy by fetching data from a local prometheus + cAdvisor setup.
-func TestTaskRanker_Start(t *testing.T) {
-	var err error
-	var prometheusDataFetcher datafetcher.Interface
-	var tRanker *TaskRanker
-
-	prometheusDataFetcher, err = prometheus.NewDataFetcher(
-		prometheus.WithPrometheusEndpoint("http://localhost:9090"))
-	assert.NoError(t, err)
-	assert.NotNil(t, prometheusDataFetcher)
-
-	tRanker, err = New(
-		WithDataFetcher(prometheusDataFetcher),
-		WithSchedule("?/5 * * * * *"),
-		WithStrategy("cpushares", []*query.LabelMatcher{
-			{Label: "container_label_task_name", Operator: query.EqualRegex, Value: "test_task_.*"},
-		}, &dummyTaskRankReceiver{}))
-	assert.NoError(t, err)
-	tRanker.Start()
-
-	<-time.After(10 * time.Second)
-	tRanker.Stop()
+	assert.Equal(t, tRankerSchedule, tRanker.Schedule)
 }

--- a/strategies/factory/factory.go
+++ b/strategies/factory/factory.go
@@ -22,19 +22,20 @@ import (
 const (
 	// cpuSharesStrategy is the name of the task ranking strategy that ranks
 	// tasks in non-increasing order based on the allocated cpu-shares.
-	// Provide this name as the strategy in the task ranker config to use this strategy
-	// for ranking tasks.
+	// Provide this name as the strategy when configuring the task ranker to use it for
+	// ranking tasks.
 	cpuSharesStrategy = "cpushares"
 )
 
-var availableStrategies = map[string]struct{}{
-	cpuSharesStrategy: {},
+var availableStrategies = map[string]strategies.Interface{
+	cpuSharesStrategy: new(strategies.TaskRankCpuSharesStrategy),
 }
 
-// GetTaskRankStrategy instantiates a new task ranking strategy.
+// GetTaskRankStrategy returns the task ranking strategy with the given name.
 func GetTaskRankStrategy(strategy string) (strategies.Interface, error) {
-	if _, ok := availableStrategies[strategy]; !ok {
+	if s, ok := availableStrategies[strategy]; !ok {
 		return nil, errors.New("invalid task ranking strategy")
+	} else {
+		return s, nil
 	}
-	return new(strategies.TaskRankCpuSharesStrategy), nil
 }

--- a/strategies/factory/factory.go
+++ b/strategies/factory/factory.go
@@ -25,10 +25,16 @@ const (
 	// Provide this name as the strategy when configuring the task ranker to use it for
 	// ranking tasks.
 	cpuSharesStrategy = "cpushares"
+	// cpuUtilStrategy is the name of the task ranking strategy that ranks
+	// tasks in non-increasing order based on the cpu utilization in the past N seconds.
+	// Provide this name as the strategy when configuring the task ranker to use it for
+	// ranking tasks.
+	cpuUtilStrategy = "cpuutil"
 )
 
 var availableStrategies = map[string]strategies.Interface{
 	cpuSharesStrategy: new(strategies.TaskRankCpuSharesStrategy),
+	cpuUtilStrategy:   new(strategies.TaskRankCpuUtilStrategy),
 }
 
 // GetTaskRankStrategy returns the task ranking strategy with the given name.

--- a/strategies/strategy.go
+++ b/strategies/strategy.go
@@ -18,9 +18,13 @@ import (
 	"github.com/pkg/errors"
 	"github.com/pradykaushik/task-ranker/query"
 	"github.com/prometheus/common/model"
+	"time"
 )
 
 type Interface interface {
+	// Init initializes the task ranking strategy, if needed.
+	// The Prometheus scrape interval is also provided.
+	Init(prometheusScrapeInterval time.Duration)
 	// SetTaskRanksReceiver registers a receiver of the task ranking results.
 	// This receiver is a callback and is used to pass the result of applying
 	// the strategy to rank tasks.
@@ -42,10 +46,17 @@ type Interface interface {
 }
 
 // Build the strategy object.
-func Build(s Interface, labelMatchers []*query.LabelMatcher, receiver TaskRanksReceiver) error {
+func Build(
+	s Interface,
+	labelMatchers []*query.LabelMatcher,
+	receiver TaskRanksReceiver,
+	prometheusScrapeInterval time.Duration) error {
+
 	if receiver == nil {
 		return errors.New("nil receiver provided")
 	}
+
+	s.Init(prometheusScrapeInterval)
 
 	s.SetTaskRanksReceiver(receiver)
 	if err := s.SetLabelMatchers(labelMatchers); err != nil {

--- a/strategies/taskRankCpuSharesStrategy.go
+++ b/strategies/taskRankCpuSharesStrategy.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pradykaushik/task-ranker/query"
 	"github.com/prometheus/common/model"
 	"sort"
+	"time"
 )
 
 // TaskRankCpuSharesStrategy is a task ranking strategy that ranks the tasks
@@ -29,7 +30,15 @@ type TaskRankCpuSharesStrategy struct {
 	receiver TaskRanksReceiver
 	// labels used to filter the time series data fetched from prometheus.
 	labels []*query.LabelMatcher
+	// dedicatedLabelNameTaskID is the dedicated label to use when filtering metrics based on task id.
+	// Storing this for quick access instead of performing another O(n) search through labels.
+	dedicatedLabelNameTaskID model.LabelName
+	// dedicatedLabelNameTaskHostname is the dedicated label to use when filtering metrics on a hostname basis.
+	// Storing this quick access instead of performing another O(n) search through labels.
+	dedicatedLabelNameTaskHostname model.LabelName
 }
+
+func (s *TaskRankCpuSharesStrategy) Init(time.Duration) {}
 
 // SetTaskRanksReceiver sets the receiver of the results of task ranking.
 func (s *TaskRankCpuSharesStrategy) SetTaskRanksReceiver(receiver TaskRanksReceiver) {
@@ -54,20 +63,37 @@ func (s *TaskRankCpuSharesStrategy) Execute(data model.Value) {
 	}
 
 	// Initializing tasks to rank.
-	var tasks []entities.RankedTask
+	var tasks = make(entities.RankedTasks)
 	for _, sampleStream := range matrix {
-		tasks = append(tasks, entities.RankedTask{
-			Metric: sampleStream.Metric,
-			// As cpu shares allocated to a container can be updated for docker containers,
-			// taking the average of allocated cpu shares.
-			Weight: s.avgCpuShare(sampleStream.Values),
-		})
+		if hostname, ok := sampleStream.Metric[s.dedicatedLabelNameTaskHostname]; ok {
+			if _, ok := tasks[entities.Hostname(hostname)]; !ok {
+				tasks[entities.Hostname(hostname)] = make([]entities.Task, 0)
+			}
+			// Fetching the task id.
+			if taskID, ok := sampleStream.Metric[s.dedicatedLabelNameTaskID]; ok {
+				tasks[entities.Hostname(hostname)] = append(tasks[entities.Hostname(hostname)],
+					entities.Task{
+						Metric:   sampleStream.Metric,
+						ID:       string(taskID),
+						Hostname: string(hostname),
+						// As cpu shares allocated to a container can be updated for docker containers,
+						// taking the average of allocated cpu shares.
+						Weight: s.avgCpuShare(sampleStream.Values),
+					})
+			} else {
+				// SHOULD NOT BE HERE.
+			}
+		} else {
+			// SHOULD NOT BE HERE.
+		}
 	}
 
-	// Sorting the tasks in non-increasing order of cpu shares.
-	sort.SliceStable(tasks, func(i, j int) bool {
-		return tasks[i].Weight > tasks[j].Weight
-	})
+	// Sorting colocated tasks in non-increasing order of cpu shares.
+	for _, colocatedTasks := range tasks {
+		sort.SliceStable(colocatedTasks, func(i, j int) bool {
+			return colocatedTasks[i].Weight > colocatedTasks[j].Weight
+		})
+	}
 
 	// Submitting the ranked tasks to the receiver.
 	s.receiver.Receive(tasks)
@@ -89,10 +115,31 @@ func (s TaskRankCpuSharesStrategy) GetMetric() string {
 }
 
 // SetLabelMatchers sets the label matchers to use to filter data.
+// This strategy mandates that a dedicated label be provided for filtering metrics based on TaskID and Hostname.
 func (s *TaskRankCpuSharesStrategy) SetLabelMatchers(labelMatchers []*query.LabelMatcher) error {
 	if len(labelMatchers) == 0 {
 		return errors.New("no label matchers provided")
 	}
+	var foundDedicatedLabelMatcherTaskID bool
+	var foundDedicatedLabelMatcherTaskHostname bool
+	for _, l := range labelMatchers {
+		if !l.Type.IsValid() {
+			return errors.New("invalid label matcher type")
+		} else if l.Type == query.TaskID {
+			foundDedicatedLabelMatcherTaskID = true
+			s.dedicatedLabelNameTaskID = model.LabelName(l.Label)
+		} else if l.Type == query.TaskHostname {
+			foundDedicatedLabelMatcherTaskHostname = true
+			s.dedicatedLabelNameTaskHostname = model.LabelName(l.Label)
+		}
+	}
+
+	if !foundDedicatedLabelMatcherTaskID {
+		return errors.New("no dedicated task ID label matcher found")
+	} else if !foundDedicatedLabelMatcherTaskHostname {
+		return errors.New("no dedicated task hostname label matcher found")
+	}
+
 	s.labels = labelMatchers
 	return nil
 }
@@ -104,5 +151,5 @@ func (s TaskRankCpuSharesStrategy) GetLabelMatchers() []*query.LabelMatcher {
 
 // GetRange returns the time unit and duration for how far back values need to be fetched.
 func (s TaskRankCpuSharesStrategy) GetRange() (query.TimeUnit, uint) {
-	return query.Seconds, 5
+	return query.Seconds, 1
 }

--- a/strategies/taskRankCpuSharesStrategy_test.go
+++ b/strategies/taskRankCpuSharesStrategy_test.go
@@ -1,0 +1,160 @@
+// Copyright 2020 Pradyumna Kaushik
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package strategies
+
+import (
+	"github.com/pradykaushik/task-ranker/entities"
+	"github.com/pradykaushik/task-ranker/query"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+// cpuSharesRanksReceiver is a receiver of the results of executing the cpushares task ranking strategy.
+type cpuSharesRanksReceiver struct {
+	rankedTasks entities.RankedTasks
+}
+
+func (r *cpuSharesRanksReceiver) Receive(rankedTasks entities.RankedTasks) {
+	r.rankedTasks = rankedTasks
+}
+
+func TestTaskRankCpuSharesStrategy_SetTaskRanksReceiver(t *testing.T) {
+	s := &TaskRankCpuSharesStrategy{}
+	s.SetTaskRanksReceiver(&cpuSharesRanksReceiver{})
+	assert.NotNil(t, s.receiver)
+}
+
+func TestTaskRankCpuSharesStrategy_GetMetric(t *testing.T) {
+	s := &TaskRankCpuSharesStrategy{}
+	assert.Equal(t, "container_spec_cpu_shares", s.GetMetric())
+}
+
+func TestTaskRankCpuSharesStrategy_SetLabelMatchers(t *testing.T) {
+	s := &TaskRankCpuSharesStrategy{}
+	err := s.SetLabelMatchers([]*query.LabelMatcher{
+		{Type: query.TaskID, Label: "test_label_1", Operator: query.NotEqual, Value: ""},
+		{Type: query.TaskHostname, Label: "test_label_2", Operator: query.Equal, Value: "localhost"},
+	})
+
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []*query.LabelMatcher{
+		{Type: query.TaskID, Label: "test_label_1", Operator: query.NotEqual, Value: ""},
+		{Type: query.TaskHostname, Label: "test_label_2", Operator: query.Equal, Value: "localhost"},
+	}, s.GetLabelMatchers())
+}
+
+func TestTaskRankCpuSharesStrategy_GetRange(t *testing.T) {
+	s := &TaskRankCpuSharesStrategy{}
+	timeUnit, qty := s.GetRange()
+	assert.Equal(t, query.Seconds, timeUnit)
+	assert.Equal(t, uint(1), qty)
+}
+
+// mockCpuSharesData returns a mock of prometheus time series data.
+// This mock has the following information.
+// 1. Three tasks with ids 'test_task_id_{1..3}'.
+// 2. Hostname for all tasks is localhost.
+// 3. task with id 'test_task_id_1' is allocated a 1024 cpu shares.
+// 4. task with id 'test_task_id_2' is allocated a 2048 cpu shares.
+// 5. task with id 'test_task_id_3' is allocated a 3072 cpu shares.
+func mockCpuSharesData(dedicatedLabelTaskID, dedicatedLabelTaskHost model.LabelName) model.Value {
+	now := time.Now()
+	return model.Value(model.Matrix{
+		{
+			Metric: map[model.LabelName]model.LabelValue{
+				dedicatedLabelTaskID:   "test_task_id_1",
+				dedicatedLabelTaskHost: "localhost",
+			},
+			Values: []model.SamplePair{
+				{Timestamp: model.Time(now.Second()), Value: 1024.0},
+			},
+		},
+		{
+			Metric: map[model.LabelName]model.LabelValue{
+				dedicatedLabelTaskID:   "test_task_id_2",
+				dedicatedLabelTaskHost: "localhost",
+			},
+			Values: []model.SamplePair{
+				{Timestamp: model.Time(now.Second()), Value: 2048.0},
+			},
+		},
+		{
+			Metric: map[model.LabelName]model.LabelValue{
+				dedicatedLabelTaskID:   "test_task_id_3",
+				dedicatedLabelTaskHost: "localhost",
+			},
+			Values: []model.SamplePair{
+				{Timestamp: model.Time(now.Second()), Value: 3072.0},
+			},
+		},
+	})
+}
+
+func TestTaskRankCpuSharesStrategy_Execute(t *testing.T) {
+	receiver := &cpuSharesRanksReceiver{}
+	s := &TaskRankCpuSharesStrategy{
+		receiver: receiver,
+		labels: []*query.LabelMatcher{
+			{Type: query.TaskID, Label: "container_label_task_id", Operator: query.NotEqual, Value: ""},
+			{Type: query.TaskHostname, Label: "container_label_task_host", Operator: query.Equal, Value: "localhost"},
+		},
+		dedicatedLabelNameTaskID:       model.LabelName("container_label_task_id"),
+		dedicatedLabelNameTaskHostname: model.LabelName("container_label_task_host"),
+	}
+
+	data := mockCpuSharesData("container_label_task_id", "container_label_task_host")
+	s.Execute(data)
+
+	expectedRankedTasks := map[entities.Hostname][]entities.Task{
+		"localhost": {
+			{
+				Metric: map[model.LabelName]model.LabelValue{
+					"container_label_task_id":   "test_task_id_3",
+					"container_label_task_host": "localhost",
+				},
+				ID:       "test_task_id_3",
+				Hostname: "localhost",
+				Weight:   3072.0,
+			},
+			{
+				Metric: map[model.LabelName]model.LabelValue{
+					"container_label_task_id":   "test_task_id_2",
+					"container_label_task_host": "localhost",
+				},
+				ID:       "test_task_id_2",
+				Hostname: "localhost",
+				Weight:   2048.0,
+			},
+			{
+				Metric: map[model.LabelName]model.LabelValue{
+					"container_label_task_id":   "test_task_id_1",
+					"container_label_task_host": "localhost",
+				},
+				ID:       "test_task_id_1",
+				Hostname: "localhost",
+				Weight:   1024.0,
+			},
+		},
+	}
+
+	assert.Equal(t, len(expectedRankedTasks), len(receiver.rankedTasks))
+
+	_, ok := expectedRankedTasks["localhost"]
+	_, localhostIsInRankedTasks := receiver.rankedTasks["localhost"]
+	assert.True(t, ok == localhostIsInRankedTasks)
+
+	assert.ElementsMatch(t, expectedRankedTasks["localhost"], receiver.rankedTasks["localhost"])
+}

--- a/strategies/taskRankCpuUtilStrategy.go
+++ b/strategies/taskRankCpuUtilStrategy.go
@@ -1,0 +1,212 @@
+// Copyright 2020 Pradyumna Kaushik
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package strategies
+
+import (
+	"github.com/pkg/errors"
+	"github.com/pradykaushik/task-ranker/entities"
+	"github.com/pradykaushik/task-ranker/query"
+	"github.com/prometheus/common/model"
+	"math"
+	"sort"
+	"time"
+)
+
+// TaskRankCpuUtilStrategy is a task ranking strategy that ranks the tasks
+// in non-increasing order based on the cpu utilization (%) in the past 5 intervals of time.
+//
+// For example, if Prometheus scrapes metrics every 1s, then each time interval is 1s long.
+// This strategy then would then rank tasks based on their cpu utilization in the past 5 seconds.
+type TaskRankCpuUtilStrategy struct {
+	// receiver of the results of task ranking.
+	receiver TaskRanksReceiver
+	// labels used to filter the time series data fetched from prometheus.
+	labels []*query.LabelMatcher
+	// dedicatedLabelNameTaskID is the dedicated label to use when filtering metrics based on task id.
+	// Storing this for quick access to prevent another O(n) search through labels.
+	dedicatedLabelNameTaskID model.LabelName
+	// dedicatedLabelNameTaskHostname is the dedicated label to use when filtering metrics on a hostname basis.
+	// Storing this for quick access to prevent another O(n) search through labels.
+	dedicatedLabelNameTaskHostname model.LabelName
+	// prometheusScrapeInterval corresponds to the time interval between two successive metrics scrapes.
+	prometheusScrapeInterval time.Duration
+}
+
+// Init initializes the prometheus scrape interval.
+func (s *TaskRankCpuUtilStrategy) Init(prometheusScrapeInterval time.Duration) {
+	s.prometheusScrapeInterval = prometheusScrapeInterval
+}
+
+// SetTaskRanksReceiver sets the receiver of the task ranking results.
+func (s *TaskRankCpuUtilStrategy) SetTaskRanksReceiver(receiver TaskRanksReceiver) {
+	s.receiver = receiver
+}
+
+// Execute the strategy using the provided data.
+func (s *TaskRankCpuUtilStrategy) Execute(data model.Value) {
+	valueT := data.Type()
+	var matrix model.Matrix
+	// Safety check to make sure that we cast to matrix only if value type is matrix.
+	// Note, however, that as the strategy decides the metric and the range for fetching data,
+	// it can assume the value type. For example, if a range is provided, then the value type would
+	// be a matrix.
+	switch valueT {
+	case model.ValMatrix:
+		matrix = data.(model.Matrix)
+	default:
+		// invalid value type.
+		// TODO do not ignore this. maybe log it?
+	}
+
+	// cpuLabelName is the label name that can be used to fetch the cpu associated with the usage data.
+	const cpuLabelName model.LabelName = "cpu"
+
+	type hostValueT model.LabelValue
+	type taskIDValueT model.LabelValue
+
+	var ok bool
+	// allTasksCpuUsageSeconds stores the cpu utilization (%) for all tasks on each cpu on each host.
+	allTasksCpuUsageSeconds := make(map[hostValueT]map[taskIDValueT]*entities.Task)
+
+	// Parse Prometheus metrics.
+	// TODO (pkaushi1) make efficient and parallelize parsing of Prometheus metrics.
+	for _, sampleStream := range matrix {
+		// Not considering task for ranking if < 2 data points retrieved.
+		if len(sampleStream.Values) < 2 {
+			continue
+		}
+
+		var hostname model.LabelValue
+		var colocatedTasksCpuUsageSeconds map[taskIDValueT]*entities.Task
+		if hostname, ok = sampleStream.Metric[s.dedicatedLabelNameTaskHostname]; ok {
+			if colocatedTasksCpuUsageSeconds, ok = allTasksCpuUsageSeconds[hostValueT(hostname)]; !ok {
+				// First time fetching metrics from this host.
+				colocatedTasksCpuUsageSeconds = make(map[taskIDValueT]*entities.Task)
+				allTasksCpuUsageSeconds[hostValueT(hostname)] = colocatedTasksCpuUsageSeconds
+			}
+
+			var taskID model.LabelValue
+			var taskCpuUsage *entities.Task
+			if taskID, ok = sampleStream.Metric[s.dedicatedLabelNameTaskID]; ok {
+				if taskCpuUsage, ok = colocatedTasksCpuUsageSeconds[taskIDValueT(taskID)]; !ok {
+					// First time fetching metrics for task. Recording taskID and hostname to help consolidation.
+					taskCpuUsage = &entities.Task{
+						Metric:   sampleStream.Metric,
+						Weight:   0.0,
+						ID:       string(taskID),
+						Hostname: string(hostname),
+					}
+
+					colocatedTasksCpuUsageSeconds[taskIDValueT(taskID)] = taskCpuUsage
+				}
+
+				if _, ok = sampleStream.Metric[cpuLabelName]; ok {
+					// Calculating and recording the cpu utilization (%) of this task on this cpu.
+					// Adding it to an accumulator that will later be used as the cpu utilization of
+					// this task across all cpus.
+					taskCpuUsage.Weight += s.cpuUtil(sampleStream.Values)
+				} else {
+					// CPU usage data does not correspond to a particular cpu.
+					// TODO do not ignore this. We should instead log this.
+				}
+			}
+		} else {
+			// Either hostname not exported along with the metrics, or
+			// Task Hostname dedicated label provided is incorrect.
+			// TODO do not ignore this. We should log this instead.
+		}
+	}
+
+	// Rank colocated tasks in non-increasing order based on their total cpu utilization (%)
+	// on the entire host (all cpus).
+	rankedTasks := make(entities.RankedTasks)
+	for hostname, colocatedTasksCpuUsageSeconds := range allTasksCpuUsageSeconds {
+		for _, taskCpuUsage := range colocatedTasksCpuUsageSeconds {
+			taskCpuUsage.Weight = s.round(taskCpuUsage.Weight)
+			rankedTasks[entities.Hostname(hostname)] = append(rankedTasks[entities.Hostname(hostname)], *taskCpuUsage)
+		}
+
+		// Sorting colocated tasks.
+		sort.SliceStable(rankedTasks[entities.Hostname(hostname)], func(i, j int) bool {
+			return rankedTasks[entities.Hostname(hostname)][i].Weight >=
+				rankedTasks[entities.Hostname(hostname)][j].Weight
+		})
+	}
+
+	// Submitting ranked tasks to the receiver.
+	s.receiver.Receive(rankedTasks)
+}
+
+// cpuUtilPrecision defines the precision for cpu utilization (%) values.
+// As cpu utilization can be less than 1%, the precision is set to 2.
+const cpuUtilPrecision = 2
+
+// round the cpu utilization (%) to the above specified precision.
+func (s TaskRankCpuUtilStrategy) round(cpuUtil float64) float64 {
+	multiplier := math.Pow10(cpuUtilPrecision)
+	magnified := cpuUtil * multiplier
+	return math.Round(magnified) / multiplier
+}
+
+// cpuUtil calculates and returns the cpu utilization (%) for the task.
+// Elapsed time is calculated as the number of seconds between oldest and newest value by
+// factoring in the prometheus scrape interval.
+func (s TaskRankCpuUtilStrategy) cpuUtil(values []model.SamplePair) float64 {
+	n := len(values)
+	return 100.0 * ((float64(values[n-1].Value) - float64(values[0].Value)) /
+		(float64(n-1) * s.prometheusScrapeInterval.Seconds()))
+}
+
+// GetMetric returns the name of the metric to query.
+func (s TaskRankCpuUtilStrategy) GetMetric() string {
+	// TODO convert this to constant.
+	return "container_cpu_usage_seconds_total"
+}
+
+// SetLabelMatchers sets the label matchers to use when filtering data.
+// This strategy mandates that a dedicated label be provided for filtering metrics based on TaskID and Hostname.
+func (s *TaskRankCpuUtilStrategy) SetLabelMatchers(labelMatchers []*query.LabelMatcher) error {
+	var foundDedicatedLabelMatcherTaskID bool
+	var foundDedicatedLabelMatcherTaskHostname bool
+	for _, l := range labelMatchers {
+		if !l.Type.IsValid() {
+			return errors.New("invalid label matcher type")
+		} else if l.Type == query.TaskID {
+			foundDedicatedLabelMatcherTaskID = true
+			s.dedicatedLabelNameTaskID = model.LabelName(l.Label)
+		} else if l.Type == query.TaskHostname {
+			foundDedicatedLabelMatcherTaskHostname = true
+			s.dedicatedLabelNameTaskHostname = model.LabelName(l.Label)
+		}
+	}
+
+	if !foundDedicatedLabelMatcherTaskID {
+		return errors.New("no dedicated task ID label matcher found")
+	} else if !foundDedicatedLabelMatcherTaskHostname {
+		return errors.New("no dedicated task hostname label matcher found")
+	}
+
+	s.labels = labelMatchers
+	return nil
+}
+
+// GetLabelMatchers returns the label matchers to be used to filter data.
+func (s TaskRankCpuUtilStrategy) GetLabelMatchers() []*query.LabelMatcher {
+	return s.labels
+}
+
+// GetRange returns the time unit and duration for how far back (in seconds) values need to be fetched.
+func (s TaskRankCpuUtilStrategy) GetRange() (query.TimeUnit, uint) {
+	return query.Seconds, uint(5 * int(s.prometheusScrapeInterval.Seconds()))
+}

--- a/strategies/taskRankCpuUtilStrategy_test.go
+++ b/strategies/taskRankCpuUtilStrategy_test.go
@@ -1,0 +1,233 @@
+// Copyright 2020 Pradyumna Kaushik
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package strategies
+
+import (
+	"github.com/pradykaushik/task-ranker/entities"
+	"github.com/pradykaushik/task-ranker/query"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+// cpuUtilRanksReceiver is a receiver of the results of executing the cpuutil task ranking strategy.
+type cpuUtilRanksReceiver struct {
+	rankedTasks entities.RankedTasks
+}
+
+func (r *cpuUtilRanksReceiver) Receive(rankedTasks entities.RankedTasks) {
+	r.rankedTasks = rankedTasks
+}
+
+func TestTaskRankCpuUtilStrategy_SetTaskRanksReceiver(t *testing.T) {
+	s := &TaskRankCpuUtilStrategy{}
+	s.SetTaskRanksReceiver(&cpuUtilRanksReceiver{})
+	assert.NotNil(t, s.receiver)
+}
+
+func TestTaskRankCpuUtilStrategy_GetMetric(t *testing.T) {
+	s := &TaskRankCpuUtilStrategy{}
+	assert.Equal(t, "container_cpu_usage_seconds_total", s.GetMetric())
+}
+
+func TestTaskRankCpuUtilStrategy_SetLabelMatchers(t *testing.T) {
+	s := &TaskRankCpuUtilStrategy{}
+	err := s.SetLabelMatchers([]*query.LabelMatcher{
+		{Type: query.TaskID, Label: "test_label_1", Operator: query.NotEqual, Value: ""},
+		{Type: query.TaskHostname, Label: "test_label_2", Operator: query.Equal, Value: "localhost"},
+	})
+
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []*query.LabelMatcher{
+		{Type: query.TaskID, Label: "test_label_1", Operator: query.NotEqual, Value: ""},
+		{Type: query.TaskHostname, Label: "test_label_2", Operator: query.Equal, Value: "localhost"},
+	}, s.GetLabelMatchers())
+}
+
+func TestTaskRankCpuUtilStrategy_GetRange(t *testing.T) {
+	s := &TaskRankCpuUtilStrategy{prometheusScrapeInterval: 1 * time.Second}
+
+	checkRange := func(strategy *TaskRankCpuUtilStrategy) {
+		timeUnit, qty := strategy.GetRange()
+		assert.Equal(t, query.Seconds, timeUnit)
+		assert.Equal(t, uint(5*strategy.prometheusScrapeInterval.Seconds()), qty)
+	}
+
+	count := 5
+	for count > 1 {
+		s.prometheusScrapeInterval = time.Duration(rand.Int63n(10)) * time.Second
+		checkRange(s)
+		count--
+	}
+}
+
+// mockCpuUtilData returns a mock of prometheus time series data.
+// This mock has the following information.
+// 1. Three tasks with ids 'test_task_id_{1..3}'.
+// 2. Hostname for all tasks is localhost.
+// 3. For each task, cpu usage data is provided for two cpus, 'cpu00' and 'cpu01'.
+// 4. task with id 'test_task_id_1' shows cpu utilization of 22.5% on each cpu.
+// 5. task with id 'test_task_id_2' shows cpu utilization of 30% on each cpu.
+// 6. task with id 'test_task_id_3' shows cpu utilization of 67.5% on each cpu.
+func mockCpuUtilData(dedicatedLabelTaskID, dedicatedLabelTaskHost model.LabelName) model.Value {
+	now := time.Now()
+	return model.Value(model.Matrix{
+		{
+			Metric: map[model.LabelName]model.LabelValue{
+				dedicatedLabelTaskID:   "test_task_id_1",
+				dedicatedLabelTaskHost: "localhost",
+				"cpu":                  "cpu00",
+			},
+			Values: []model.SamplePair{
+				{Timestamp: model.Time(now.Unix()), Value: 0.5},
+				{Timestamp: model.Time(now.Add(1 * time.Second).Unix()), Value: 0.8},
+				{Timestamp: model.Time(now.Add(2 * time.Second).Unix()), Value: 1.1},
+				{Timestamp: model.Time(now.Add(3 * time.Second).Unix()), Value: 1.3},
+				{Timestamp: model.Time(now.Add(4 * time.Second).Unix()), Value: 1.4},
+			},
+		},
+		{
+			Metric: map[model.LabelName]model.LabelValue{
+				dedicatedLabelTaskID:   "test_task_id_1",
+				dedicatedLabelTaskHost: "localhost",
+				"cpu":                  "cpu01",
+			},
+			Values: []model.SamplePair{
+				{Timestamp: model.Time(now.Unix()), Value: 0.5},
+				{Timestamp: model.Time(now.Add(1 * time.Second).Unix()), Value: 0.8},
+				{Timestamp: model.Time(now.Add(2 * time.Second).Unix()), Value: 1.1},
+				{Timestamp: model.Time(now.Add(3 * time.Second).Unix()), Value: 1.3},
+				{Timestamp: model.Time(now.Add(4 * time.Second).Unix()), Value: 1.4},
+			},
+		},
+		{
+			Metric: map[model.LabelName]model.LabelValue{
+				dedicatedLabelTaskID:   "test_task_id_2",
+				dedicatedLabelTaskHost: "localhost",
+				"cpu":                  "cpu00",
+			},
+			Values: []model.SamplePair{
+				{Timestamp: model.Time(now.Unix()), Value: 0.5},
+				{Timestamp: model.Time(now.Add(1 * time.Second).Unix()), Value: 0.9},
+				{Timestamp: model.Time(now.Add(2 * time.Second).Unix()), Value: 1.3},
+				{Timestamp: model.Time(now.Add(3 * time.Second).Unix()), Value: 1.5},
+				{Timestamp: model.Time(now.Add(4 * time.Second).Unix()), Value: 1.7},
+			},
+		},
+		{
+			Metric: map[model.LabelName]model.LabelValue{
+				dedicatedLabelTaskID:   "test_task_id_2",
+				dedicatedLabelTaskHost: "localhost",
+				"cpu":                  "cpu01",
+			},
+			Values: []model.SamplePair{
+				{Timestamp: model.Time(now.Unix()), Value: 0.5},
+				{Timestamp: model.Time(now.Add(1 * time.Second).Unix()), Value: 0.9},
+				{Timestamp: model.Time(now.Add(2 * time.Second).Unix()), Value: 1.3},
+				{Timestamp: model.Time(now.Add(3 * time.Second).Unix()), Value: 1.5},
+				{Timestamp: model.Time(now.Add(4 * time.Second).Unix()), Value: 1.7},
+			},
+		},
+		{
+			Metric: map[model.LabelName]model.LabelValue{
+				dedicatedLabelTaskID:   "test_task_id_3",
+				dedicatedLabelTaskHost: "localhost",
+				"cpu":                  "cpu00",
+			},
+			Values: []model.SamplePair{
+				{Timestamp: model.Time(now.Unix()), Value: 0.3},
+				{Timestamp: model.Time(now.Add(1 * time.Second).Unix()), Value: 0.9},
+				{Timestamp: model.Time(now.Add(2 * time.Second).Unix()), Value: 1.6},
+				{Timestamp: model.Time(now.Add(3 * time.Second).Unix()), Value: 2.5},
+				{Timestamp: model.Time(now.Add(4 * time.Second).Unix()), Value: 3.0},
+			},
+		},
+		{
+			Metric: map[model.LabelName]model.LabelValue{
+				dedicatedLabelTaskID:   "test_task_id_3",
+				dedicatedLabelTaskHost: "localhost",
+				"cpu":                  "cpu01",
+			},
+			Values: []model.SamplePair{
+				{Timestamp: model.Time(now.Unix()), Value: 0.3},
+				{Timestamp: model.Time(now.Add(1 * time.Second).Unix()), Value: 0.9},
+				{Timestamp: model.Time(now.Add(2 * time.Second).Unix()), Value: 1.6},
+				{Timestamp: model.Time(now.Add(3 * time.Second).Unix()), Value: 2.5},
+				{Timestamp: model.Time(now.Add(4 * time.Second).Unix()), Value: 3.0},
+			},
+		},
+	})
+}
+
+func TestTaskRankCpuUtilStrategy_Execute(t *testing.T) {
+	receiver := &cpuUtilRanksReceiver{}
+	s := &TaskRankCpuUtilStrategy{
+		receiver: receiver,
+		labels: []*query.LabelMatcher{
+			{Type: query.TaskID, Label: "container_label_task_id", Operator: query.NotEqual, Value: ""},
+			{Type: query.TaskHostname, Label: "container_label_task_host", Operator: query.Equal, Value: "localhost"},
+		},
+		dedicatedLabelNameTaskID:       model.LabelName("container_label_task_id"),
+		dedicatedLabelNameTaskHostname: model.LabelName("container_label_task_host"),
+		prometheusScrapeInterval:       1 * time.Second,
+	}
+
+	data := mockCpuUtilData("container_label_task_id", "container_label_task_host")
+	s.Execute(data)
+
+	expectedRankedTasks := map[entities.Hostname][]entities.Task{
+		"localhost": {
+			{
+				Metric: map[model.LabelName]model.LabelValue{
+					"container_label_task_id":   "test_task_id_3",
+					"container_label_task_host": "localhost",
+					"cpu":                       "cpu00",
+				},
+				ID:       "test_task_id_3",
+				Hostname: "localhost",
+				Weight:   135.0, // sum of cpu util (%) on cpu00 and cpu01.
+			},
+			{
+				Metric: map[model.LabelName]model.LabelValue{
+					"container_label_task_id":   "test_task_id_2",
+					"container_label_task_host": "localhost",
+					"cpu":                       "cpu00",
+				},
+				ID:       "test_task_id_2",
+				Hostname: "localhost",
+				Weight:   60.0, // sum of cpu util (%) on cpu00 and cpu01.
+			},
+			{
+				Metric: map[model.LabelName]model.LabelValue{
+					"container_label_task_id":   "test_task_id_1",
+					"container_label_task_host": "localhost",
+					"cpu":                       "cpu00",
+				},
+				ID:       "test_task_id_1",
+				Hostname: "localhost",
+				Weight:   45.0, // sum of cpu util (%) on cpu00 and cpu01.
+			},
+		},
+	}
+
+	assert.Equal(t, len(expectedRankedTasks), len(receiver.rankedTasks))
+
+	_, ok := expectedRankedTasks["localhost"]
+	_, localhostIsInRankedTasks := receiver.rankedTasks["localhost"]
+	assert.True(t, ok == localhostIsInRankedTasks)
+
+	assert.ElementsMatch(t, expectedRankedTasks["localhost"], receiver.rankedTasks["localhost"])
+}

--- a/strategies/taskRanksReceiver.go
+++ b/strategies/taskRanksReceiver.go
@@ -20,5 +20,5 @@ import "github.com/pradykaushik/task-ranker/entities"
 type TaskRanksReceiver interface {
 	// Receive the ranked tasks and their corresponding information.
 	// Task at position i is ranked higher than task at position i+1.
-	Receive([]entities.RankedTask)
+	Receive(entities.RankedTasks)
 }

--- a/taskdockerfile/Dockerfile
+++ b/taskdockerfile/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2020 Pradyumna Kaushik
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM python:3.5-alpine
+
+ADD ./hello.py /
+
+RUN cd /
+
+CMD ["python3", "hello.py"]

--- a/taskdockerfile/hello.py
+++ b/taskdockerfile/hello.py
@@ -1,0 +1,32 @@
+# Copyright 2020 Pradyumna Kaushik
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import time
+import signal
+import sys
+
+dev_null_file = open("/dev/null", "w")
+
+# When we run 'docker stop', SIGTERM is sent to the running process.
+def sig_handler(signal, frame):
+    print("GOOD BYE FROM TASK-RANKER!!")
+    dev_null_file.close()
+    sys.exit(0)
+
+signal.signal(signal.SIGTERM, sig_handler)
+signal.signal(signal.SIGINT, sig_handler)
+
+while True:
+    f = open("/dev/null", "w")
+    f.write("hello world")
+    time.sleep(1)

--- a/tear_down_test_env
+++ b/tear_down_test_env
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Stopping and Removing containers corresponding to the tasks.
+for i in {1..3}; do
+  task_name="test_hello_${i}"
+  docker stop $task_name
+  docker rm $task_name
+done
+
+# Bringing down prometheus and cAdvisor.
+docker-compose down


### PR DESCRIPTION
1. Implemented cpu utilization based task ranking.
2. Updated type of RankedTasks. This now breaks compatibility with previous versions.
3. Added setup and tear-down scripts for local testing.
4. Split ranker_test.go into ranker_test.go (unit tests) and ranker_e2e_test.go (end-to-end tests).