### PR TITLE
configurable range + strategy

### DIFF
--- a/ranker_test.go
+++ b/ranker_test.go
@@ -24,19 +24,33 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	tRanker, initErr := initTaskRanker("cpushares")
-	assert.NoError(t, initErr)
-	assert.NotNil(t, tRanker)
-	assert.NotNil(t, tRanker.DataFetcher)
-	assert.NotNil(t, tRanker.Strategy)
-	assert.Equal(t, "http://localhost:9090",
-		tRanker.DataFetcher.(*prometheus.DataFetcher).GetEndpoint())
-	assert.ElementsMatch(t, []*query.LabelMatcher{
-		{Type: query.TaskID, Label: "container_label_task_id", Operator: query.EqualRegex, Value: "hello_.*"},
-		{Type: query.TaskHostname, Label: "container_label_task_host", Operator: query.Equal, Value: "localhost"},
-	}, tRanker.Strategy.(*strategies.TaskRankCpuSharesStrategy).GetLabelMatchers())
-	parser := cron.NewParser(cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
-	tRankerSchedule, err := parser.Parse("?/5 * * * * *")
-	assert.NoError(t, err)
-	assert.Equal(t, tRankerSchedule, tRanker.Schedule)
+	test := func(tRanker *TaskRanker, initErr error) {
+		assert.NoError(t, initErr)
+		assert.NotNil(t, tRanker)
+		assert.NotNil(t, tRanker.DataFetcher)
+		assert.NotNil(t, tRanker.Strategy)
+		assert.Equal(t, "http://localhost:9090",
+			tRanker.DataFetcher.(*prometheus.DataFetcher).GetEndpoint())
+		assert.ElementsMatch(t, []*query.LabelMatcher{
+			{Type: query.TaskID, Label: "container_label_task_id", Operator: query.EqualRegex, Value: "hello_.*"},
+			{Type: query.TaskHostname, Label: "container_label_task_host", Operator: query.Equal, Value: "localhost"},
+		}, tRanker.Strategy.(*strategies.TaskRankCpuSharesStrategy).GetLabelMatchers())
+		parser := cron.NewParser(cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+		tRankerSchedule, err := parser.Parse("?/5 * * * * *")
+		assert.NoError(t, err)
+		assert.Equal(t, tRankerSchedule, tRanker.Schedule)
+	}
+
+	t.Run("using WithStrategy", func(t *testing.T) {
+		tRanker, initErr := initTaskRanker("cpushares")
+		test(tRanker, initErr)
+	})
+
+	t.Run("using WithStrategyOptions", func(t *testing.T) {
+		tRanker, initErr := initTaskRankerOptions("cpushares")
+		test(tRanker, initErr)
+		timeUnit, qty := tRanker.Strategy.GetRange()
+		assert.Equal(t, query.Seconds, timeUnit)
+		assert.Equal(t, uint(5), qty)
+	})
 }

--- a/strategies/strategy.go
+++ b/strategies/strategy.go
@@ -22,9 +22,10 @@ import (
 )
 
 type Interface interface {
-	// Init initializes the task ranking strategy, if needed.
-	// The Prometheus scrape interval is also provided.
-	Init(prometheusScrapeInterval time.Duration)
+	// Initialize any other internal data structure and perform any further setup operations.
+	Init()
+	// SetPrometheusScrapeInterval sets the prometheus scrape interval.
+	SetPrometheusScrapeInterval(time.Duration)
 	// SetTaskRanksReceiver registers a receiver of the task ranking results.
 	// This receiver is a callback and is used to pass the result of applying
 	// the strategy to rank tasks.
@@ -43,24 +44,64 @@ type Interface interface {
 	// Range returns the duration specifying how far back in time data needs to be fetched.
 	// Returns the unit of time along with an integer quantifying the duration.
 	GetRange() (query.TimeUnit, uint)
+	// SetRange sets the time duration for the range query.
+	SetRange(query.TimeUnit, uint)
 }
 
 // Build the strategy object.
-func Build(
-	s Interface,
-	labelMatchers []*query.LabelMatcher,
-	receiver TaskRanksReceiver,
-	prometheusScrapeInterval time.Duration) error {
-
-	if receiver == nil {
-		return errors.New("nil receiver provided")
-	}
-
-	s.Init(prometheusScrapeInterval)
-
-	s.SetTaskRanksReceiver(receiver)
-	if err := s.SetLabelMatchers(labelMatchers); err != nil {
-		return errors.Wrap(err, "invalid label matchers for strategy")
+func Build(s Interface, options ...Option) error {
+	s.Init()
+	for _, opt := range options {
+		if err := opt(s); err != nil {
+			return errors.Wrap(err, "failed to build strategy")
+		}
 	}
 	return nil
+}
+
+// Options for configuring strategies.
+type Option func(Interface) error
+
+// WithLabelMatchers returns an option that initializes the label matchers to be used by the strategy.
+func WithLabelMatchers(labelMatchers []*query.LabelMatcher) Option {
+	return func(strategy Interface) error {
+		if labelMatchers == nil {
+			return errors.New("invalid label matchers: nil provided")
+		}
+		return strategy.SetLabelMatchers(labelMatchers)
+	}
+}
+
+// WithRange returns an option that initializes the time unit and duration, if using range queries.
+func WithRange(timeUnit query.TimeUnit, qty uint) Option {
+	return func(strategy Interface) error {
+		if !timeUnit.IsValid() {
+			return errors.New("invalid time unit provided for range")
+		}
+		if qty == 0 {
+			return errors.New("time duration cannot be 0")
+		}
+		strategy.SetRange(timeUnit, qty)
+		return nil
+	}
+}
+
+// WithTaskRanksReceiver returns an option that initializes the receiver to which the task ranking results
+// are submitted.
+func WithTaskRanksReceiver(receiver TaskRanksReceiver) Option {
+	return func(strategy Interface) error {
+		if receiver == nil {
+			return errors.New("nil receiver provided")
+		}
+		strategy.SetTaskRanksReceiver(receiver)
+		return nil
+	}
+}
+
+// WithPrometheusScrapeInterval returns an option that initializes the prometheus scrape interval.
+func WithPrometheusScrapeInterval(prometheusScrapeInterval time.Duration) Option {
+	return func(strategy Interface) error {
+		strategy.SetPrometheusScrapeInterval(prometheusScrapeInterval)
+		return nil
+	}
 }

--- a/strategies/taskRankCpuSharesStrategy_test.go
+++ b/strategies/taskRankCpuSharesStrategy_test.go
@@ -31,19 +31,25 @@ func (r *cpuSharesRanksReceiver) Receive(rankedTasks entities.RankedTasks) {
 	r.rankedTasks = rankedTasks
 }
 
-func TestTaskRankCpuSharesStrategy_SetTaskRanksReceiver(t *testing.T) {
+func initCpusharesStrategy() *TaskRankCpuSharesStrategy {
 	s := &TaskRankCpuSharesStrategy{}
+	s.Init()
+	return s
+}
+
+func TestTaskRankCpuSharesStrategy_SetTaskRanksReceiver(t *testing.T) {
+	s := initCpusharesStrategy()
 	s.SetTaskRanksReceiver(&cpuSharesRanksReceiver{})
 	assert.NotNil(t, s.receiver)
 }
 
 func TestTaskRankCpuSharesStrategy_GetMetric(t *testing.T) {
-	s := &TaskRankCpuSharesStrategy{}
+	s := initCpusharesStrategy()
 	assert.Equal(t, "container_spec_cpu_shares", s.GetMetric())
 }
 
 func TestTaskRankCpuSharesStrategy_SetLabelMatchers(t *testing.T) {
-	s := &TaskRankCpuSharesStrategy{}
+	s := initCpusharesStrategy()
 	err := s.SetLabelMatchers([]*query.LabelMatcher{
 		{Type: query.TaskID, Label: "test_label_1", Operator: query.NotEqual, Value: ""},
 		{Type: query.TaskHostname, Label: "test_label_2", Operator: query.Equal, Value: "localhost"},
@@ -57,10 +63,10 @@ func TestTaskRankCpuSharesStrategy_SetLabelMatchers(t *testing.T) {
 }
 
 func TestTaskRankCpuSharesStrategy_GetRange(t *testing.T) {
-	s := &TaskRankCpuSharesStrategy{}
+	s := initCpusharesStrategy()
 	timeUnit, qty := s.GetRange()
-	assert.Equal(t, query.Seconds, timeUnit)
-	assert.Equal(t, uint(1), qty)
+	assert.Equal(t, query.None, timeUnit)
+	assert.Equal(t, uint(0), qty)
 }
 
 // mockCpuSharesData returns a mock of prometheus time series data.
@@ -114,6 +120,7 @@ func TestTaskRankCpuSharesStrategy_Execute(t *testing.T) {
 		dedicatedLabelNameTaskID:       model.LabelName("container_label_task_id"),
 		dedicatedLabelNameTaskHostname: model.LabelName("container_label_task_host"),
 	}
+	s.Init()
 
 	data := mockCpuSharesData("container_label_task_id", "container_label_task_host")
 	s.Execute(data)

--- a/strategies/taskRankCpuUtilStrategy.go
+++ b/strategies/taskRankCpuUtilStrategy.go
@@ -41,10 +41,19 @@ type TaskRankCpuUtilStrategy struct {
 	dedicatedLabelNameTaskHostname model.LabelName
 	// prometheusScrapeInterval corresponds to the time interval between two successive metrics scrapes.
 	prometheusScrapeInterval time.Duration
+	// Time duration for range query.
+	rangeTimeUnit query.TimeUnit
+	rangeQty      uint
 }
 
-// Init initializes the prometheus scrape interval.
-func (s *TaskRankCpuUtilStrategy) Init(prometheusScrapeInterval time.Duration) {
+func (s *TaskRankCpuUtilStrategy) Init() {
+	// By default, rank tasks based on past 5 seconds cpu usage.
+	s.rangeTimeUnit = query.Seconds
+	s.rangeQty = 5
+}
+
+// SetPrometheusScrapeInterval sets the scrape interval of prometheus.
+func (s *TaskRankCpuUtilStrategy) SetPrometheusScrapeInterval(prometheusScrapeInterval time.Duration) {
 	s.prometheusScrapeInterval = prometheusScrapeInterval
 }
 
@@ -208,5 +217,13 @@ func (s TaskRankCpuUtilStrategy) GetLabelMatchers() []*query.LabelMatcher {
 
 // GetRange returns the time unit and duration for how far back (in seconds) values need to be fetched.
 func (s TaskRankCpuUtilStrategy) GetRange() (query.TimeUnit, uint) {
-	return query.Seconds, uint(5 * int(s.prometheusScrapeInterval.Seconds()))
+	return s.rangeTimeUnit, s.rangeQty
+	// return query.Seconds, uint(5 * int(s.prometheusScrapeInterval.Seconds()))
+}
+
+// SetRange sets the time duration for the range query.
+// For cpu-util ranking strategy the time duration has to be > 1s as you need two data points to calculate cpu utilization.
+func (s *TaskRankCpuUtilStrategy) SetRange(timeUnit query.TimeUnit, qty uint) {
+	s.rangeTimeUnit = timeUnit
+	s.rangeQty = qty
 }

--- a/strategies/taskRankCpuUtilStrategy.go
+++ b/strategies/taskRankCpuUtilStrategy.go
@@ -223,7 +223,14 @@ func (s TaskRankCpuUtilStrategy) GetRange() (query.TimeUnit, uint) {
 
 // SetRange sets the time duration for the range query.
 // For cpu-util ranking strategy the time duration has to be > 1s as you need two data points to calculate cpu utilization.
+// If the provided time duration <= 1s, the default duration of 5 intervals of time is used, where each
+// interval of time is equal to the prometheus scrape interval.
 func (s *TaskRankCpuUtilStrategy) SetRange(timeUnit query.TimeUnit, qty uint) {
-	s.rangeTimeUnit = timeUnit
-	s.rangeQty = qty
+	if !timeUnit.IsValid() || ((timeUnit == query.Seconds) && qty <= 1) {
+		s.rangeTimeUnit = query.Seconds
+		s.rangeQty = uint(5 * int(s.prometheusScrapeInterval.Seconds()))
+	} else {
+		s.rangeTimeUnit = timeUnit
+		s.rangeQty = qty
+	}
 }


### PR DESCRIPTION
With this commit, the time duration for range queries can also be
configured. This allows for more fine grained control over the number
of data points on which the strategies is to be applied.
    
For backwards compatibility the earlier WithStrategy(...) function
can still be used. However, note that this results in the default
setting of range duration (as exposed by the strategy) being used.
If the time duration needs to be configured, then WithStrategyOptions(...)
should now be used.
    
Retrofitted cpushares task ranking strategy to now parse either a matrix
or a vector depending on whether a range query is used.
    
Fixed the test code.