### PR TITLE
fix cpu util calc by adding cumulative usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,30 +75,17 @@ tRanker, err = New(
     }, new(dummyTaskRanksReceiver), 1*time.Second))
 ```
 
-You can now also configure the strategies using initialization [options](./strategies/strategy.go). This allows for 
+You can now also configure the strategies using initialization [options](./strategies/strategy.go). This also allows for 
 configuring the time duration of range queries, enabling fine-grained control over the number of data points
-over which the strategy is applied. See below example for strategy configuration using options.
+over which the strategy is applied. See below code snippet for strategy configuration using options.
 ```go
-type dummyTaskRanksReceiver struct{}
-
-func (r *dummyTaskRanksReceiver) Receive(rankedTasks entities.RankedTasks) {
-	log.Println(rankedTasks)
-}
-
-prometheusDataFetcher, err = prometheus.NewDataFetcher(
-    prometheus.WithPrometheusEndpoint("http://localhost:9090"))
-
-tRanker, err = New(
-    WithDataFetcher(prometheusDataFetcher),
-    WithSchedule("?/5 * * * * *"),
-    WithStrategyOptions("cpuutil",
-        strategies.WithLabelMatchers([]*query.LabelMatcher{
-            {Type: query.TaskID, Label: "container_label_task_id", Operator: query.NotEqual, Value: ""},
-            {Type: query.TaskHostname, Label: "container_label_task_host", Operator: query.Equal, Value: "localhost"}}),
-        strategies.WithTaskRanksReceiver(new(dummyTaskRanksReceiver)),
-        strategies.WithPrometheusScrapeInterval(1*time.Second),
-        strategies.WithRange(query.Seconds, 5)))
+WithStrategyOptions("dummyStrategy",
+    strategies.WithLabelMatchers([]*query.LabelMatcher{...}
+    strategies.WithTaskRanksReceiver(new(testTaskRanksReceiver)),
+    strategies.WithPrometheusScrapeInterval(...),
+    strategies.WithRange(query.Seconds, 5)))
 ```
+_Note: Currently, none of the strategies implemented (**cpushares** and **cpuutil**) support range queries._
 
 ##### Dedicated Label Matchers
 Dedicated Label Matchers can be used to retrieve the task ID and host information from data retrieved

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ tRanker, err = New(
         {Type: query.TaskHostname, Label: "container_label_task_host", Operator: query.Equal, Value: "localhost"},
     }, new(dummyTaskRanksReceiver), 1*time.Second))
 ```
+**The task ranker schedule (in seconds) SHOULD be a positive multiple of the prometheus scrape interval. This simplifies the calculation
+of the time difference between data points fetched from successive query executions.**
 
 You can now also configure the strategies using initialization [options](./strategies/strategy.go). This also allows for 
 configuring the time duration of range queries, enabling fine-grained control over the number of data points
@@ -82,7 +84,6 @@ over which the strategy is applied. See below code snippet for strategy configur
 WithStrategyOptions("dummyStrategy",
     strategies.WithLabelMatchers([]*query.LabelMatcher{...}
     strategies.WithTaskRanksReceiver(new(testTaskRanksReceiver)),
-    strategies.WithPrometheusScrapeInterval(...),
     strategies.WithRange(query.Seconds, 5)))
 ```
 _Note: Currently, none of the strategies implemented (**cpushares** and **cpuutil**) support range queries._

--- a/ranker.go
+++ b/ranker.go
@@ -62,13 +62,13 @@ func New(options ...Option) (*TaskRanker, error) {
 	}
 
 	// validate task ranker schedule to be a multiple of prometheus scrape interval.
-	now := time.Now()
+	now := time.Unix(50000, 50000)
 	nextTimeTRankerSchedule := tRanker.Schedule.Next(now)
 	tRankerScheduleIntervalSeconds := int(nextTimeTRankerSchedule.Sub(now).Seconds())
 	if (tRankerScheduleIntervalSeconds < int(tRanker.prometheusScrapeInterval.Seconds())) ||
 		((tRankerScheduleIntervalSeconds % int(tRanker.prometheusScrapeInterval.Seconds())) != 0) {
 		return nil, errors.New(fmt.Sprintf("task ranker schedule (%d seconds) should be a multiple of "+
-			"prometheus scrape interval (%d seconds)", tRankerScheduleIntervalSeconds, tRanker.prometheusScrapeInterval))
+			"prometheus scrape interval (%d seconds)", tRankerScheduleIntervalSeconds, int(tRanker.prometheusScrapeInterval.Seconds())))
 	}
 	// Providing the prometheus scrape interval to the strategy.
 	tRanker.Strategy.SetPrometheusScrapeInterval(tRanker.prometheusScrapeInterval)

--- a/ranker.go
+++ b/ranker.go
@@ -66,8 +66,8 @@ func New(options ...Option) (*TaskRanker, error) {
 	nextTimeTRankerSchedule := tRanker.Schedule.Next(now)
 	tRankerScheduleIntervalSeconds := int(nextTimeTRankerSchedule.Sub(now).Seconds())
 	if (tRankerScheduleIntervalSeconds < int(tRanker.prometheusScrapeInterval.Seconds())) ||
-		(tRankerScheduleIntervalSeconds%int(tRanker.prometheusScrapeInterval.Seconds())) != 0 {
-		return nil, errors.New(fmt.Sprintf("task ranker schedule (%d seconds) should be a multiple of " +
+		((tRankerScheduleIntervalSeconds % int(tRanker.prometheusScrapeInterval.Seconds())) != 0) {
+		return nil, errors.New(fmt.Sprintf("task ranker schedule (%d seconds) should be a multiple of "+
 			"prometheus scrape interval (%d seconds)", tRankerScheduleIntervalSeconds, tRanker.prometheusScrapeInterval))
 	}
 	// Providing the prometheus scrape interval to the strategy.

--- a/ranker_e2e_test.go
+++ b/ranker_e2e_test.go
@@ -51,10 +51,11 @@ func initTaskRanker(strategy string) (*TaskRanker, error) {
 	tRanker, err = New(
 		WithDataFetcher(prometheusDataFetcher),
 		WithSchedule("?/5 * * * * *"),
+		WithPrometheusScrapeInterval(1*time.Second),
 		WithStrategy(strategy, []*query.LabelMatcher{
 			{Type: query.TaskID, Label: "container_label_task_id", Operator: query.EqualRegex, Value: "hello_.*"},
 			{Type: query.TaskHostname, Label: "container_label_task_host", Operator: query.Equal, Value: "localhost"},
-		}, dummyReceiver, 1*time.Second))
+		}, dummyReceiver))
 
 	return tRanker, err
 }
@@ -74,13 +75,12 @@ func initTaskRankerOptions(strategy string) (*TaskRanker, error) {
 	tRanker, err = New(
 		WithDataFetcher(prometheusDataFetcher),
 		WithSchedule("?/5 * * * * *"),
+		WithPrometheusScrapeInterval(1*time.Second),
 		WithStrategyOptions(strategy,
 			strategies.WithLabelMatchers([]*query.LabelMatcher{
 				{Type: query.TaskID, Label: "container_label_task_id", Operator: query.EqualRegex, Value: "hello_.*"},
 				{Type: query.TaskHostname, Label: "container_label_task_host", Operator: query.Equal, Value: "localhost"}}),
-			strategies.WithTaskRanksReceiver(dummyReceiver),
-			strategies.WithPrometheusScrapeInterval(1*time.Second),
-			strategies.WithRange(query.Seconds, 5)))
+			strategies.WithTaskRanksReceiver(dummyReceiver)))
 
 	return tRanker, err
 

--- a/ranker_e2e_test.go
+++ b/ranker_e2e_test.go
@@ -102,7 +102,7 @@ func testStrategy(t *testing.T, tRanker *TaskRanker, initErr error) {
 	assert.NoError(t, initErr)
 	assert.NotNil(t, tRanker)
 	tRanker.Start()
-	<-time.After(7 * time.Second) // Enough time for one round of ranking.
+	<-time.After(13 * time.Second) // Enough time for at least one round of ranking.
 	testRanked(t)
 	tRanker.Stop()
 }

--- a/strategies/strategy.go
+++ b/strategies/strategy.go
@@ -97,11 +97,3 @@ func WithTaskRanksReceiver(receiver TaskRanksReceiver) Option {
 		return nil
 	}
 }
-
-// WithPrometheusScrapeInterval returns an option that initializes the prometheus scrape interval.
-func WithPrometheusScrapeInterval(prometheusScrapeInterval time.Duration) Option {
-	return func(strategy Interface) error {
-		strategy.SetPrometheusScrapeInterval(prometheusScrapeInterval)
-		return nil
-	}
-}

--- a/strategies/taskRankCpuUtilStrategy.go
+++ b/strategies/taskRankCpuUtilStrategy.go
@@ -24,10 +24,10 @@ import (
 )
 
 // TaskRankCpuUtilStrategy is a task ranking strategy that ranks the tasks
-// in non-increasing order based on the cpu utilization (%) in the past 5 intervals of time.
+// in non-increasing order based on their cpu utilization (%).
 //
-// For example, if Prometheus scrapes metrics every 1s, then each time interval is 1s long.
-// This strategy then would then rank tasks based on their cpu utilization in the past 5 seconds.
+// For example, if Prometheus scrapes metrics every 1s, then this strategy would rank tasks based
+// on their cpu utilization in the past second.
 type TaskRankCpuUtilStrategy struct {
 	// receiver of the results of task ranking.
 	receiver TaskRanksReceiver
@@ -41,15 +41,27 @@ type TaskRankCpuUtilStrategy struct {
 	dedicatedLabelNameTaskHostname model.LabelName
 	// prometheusScrapeInterval corresponds to the time interval between two successive metrics scrapes.
 	prometheusScrapeInterval time.Duration
+	// previousTotalCpuUsage stores the sum of cumulative cpu usage seconds for each running task.
+	previousTotalCpuUsage map[string]map[string]*taskCpuUsageInfo
 	// Time duration for range query.
+	// Note that there is a caveat in using range queries to retrieve cpu time for containers.
+	// If the tasks are pinned, then using a range > 1s works as we would always get the necessary data points for each cpu (thread).
+	// On the other hand, if the tasks are not pinned, then there is no guarantee that the necessary number of data points be available
+	// as the cpu scheduler can preempt and re-schedule the task on any available cpu.
+	// Therefore, to avoid confusion, this strategy does not use the range query.
 	rangeTimeUnit query.TimeUnit
 	rangeQty      uint
 }
 
+type taskCpuUsageInfo struct {
+	task                  *entities.Task
+	prevTotalCpuUsageTask *float64
+}
+
 func (s *TaskRankCpuUtilStrategy) Init() {
-	// By default, rank tasks based on past 5 seconds cpu usage.
-	s.rangeTimeUnit = query.Seconds
-	s.rangeQty = 5
+	s.rangeTimeUnit = query.None
+	s.rangeQty = 0
+	s.previousTotalCpuUsage = make(map[string]map[string]*taskCpuUsageInfo)
 }
 
 // SetPrometheusScrapeInterval sets the scrape interval of prometheus.
@@ -65,70 +77,64 @@ func (s *TaskRankCpuUtilStrategy) SetTaskRanksReceiver(receiver TaskRanksReceive
 // Execute the strategy using the provided data.
 func (s *TaskRankCpuUtilStrategy) Execute(data model.Value) {
 	valueT := data.Type()
-	var matrix model.Matrix
-	// Safety check to make sure that we cast to matrix only if value type is matrix.
+	var vector model.Vector
+	// Safety check to make sure that we cast to vector only if value type is vector.
 	// Note, however, that as the strategy decides the metric and the range for fetching data,
-	// it can assume the value type. For example, if a range is provided, then the value type would
-	// be a matrix.
+	// it can assume the value type.
+	// For example, if a range is provided, then the value type would be a matrix.
+	// If no range is provided, the value type would be a vector.
 	switch valueT {
-	case model.ValMatrix:
-		matrix = data.(model.Matrix)
+	case model.ValVector:
+		vector = data.(model.Vector)
 	default:
 		// invalid value type.
 		// TODO do not ignore this. maybe log it?
 	}
 
-	// cpuLabelName is the label name that can be used to fetch the cpu associated with the usage data.
-	const cpuLabelName model.LabelName = "cpu"
-
-	type hostValueT model.LabelValue
-	type taskIDValueT model.LabelValue
-
 	var ok bool
-	// allTasksCpuUsageSeconds stores the cpu utilization (%) for all tasks on each cpu on each host.
-	allTasksCpuUsageSeconds := make(map[hostValueT]map[taskIDValueT]*entities.Task)
+	// nowTotalCpuUsage stores the total cumulative cpu usage for each running task.
+	var nowTotalCpuUsage = make(map[string]map[string]float64)
 
 	// Parse Prometheus metrics.
-	// TODO (pkaushi1) make efficient and parallelize parsing of Prometheus metrics.
-	for _, sampleStream := range matrix {
-		// Not considering task for ranking if < 2 data points retrieved.
-		if len(sampleStream.Values) < 2 {
-			continue
-		}
-
+	// TODO (pradykaushik) make efficient and parallelize parsing of Prometheus metrics.
+	for _, sample := range vector {
 		var hostname model.LabelValue
-		var colocatedTasksCpuUsageSeconds map[taskIDValueT]*entities.Task
-		if hostname, ok = sampleStream.Metric[s.dedicatedLabelNameTaskHostname]; ok {
-			if colocatedTasksCpuUsageSeconds, ok = allTasksCpuUsageSeconds[hostValueT(hostname)]; !ok {
+		if hostname, ok = sample.Metric[s.dedicatedLabelNameTaskHostname]; ok {
+			if _, ok = s.previousTotalCpuUsage[string(hostname)]; !ok {
 				// First time fetching metrics from this host.
-				colocatedTasksCpuUsageSeconds = make(map[taskIDValueT]*entities.Task)
-				allTasksCpuUsageSeconds[hostValueT(hostname)] = colocatedTasksCpuUsageSeconds
+				s.previousTotalCpuUsage[string(hostname)] = make(map[string]*taskCpuUsageInfo)
+			}
+
+			if _, ok = nowTotalCpuUsage[string(hostname)]; !ok {
+				// Creating entry to record current total cumulative cpu usage for colocated tasks.
+				nowTotalCpuUsage[string(hostname)] = make(map[string]float64)
 			}
 
 			var taskID model.LabelValue
-			var taskCpuUsage *entities.Task
-			if taskID, ok = sampleStream.Metric[s.dedicatedLabelNameTaskID]; ok {
-				if taskCpuUsage, ok = colocatedTasksCpuUsageSeconds[taskIDValueT(taskID)]; !ok {
+			if taskID, ok = sample.Metric[s.dedicatedLabelNameTaskID]; ok {
+				if taskTotalCpuUsage, ok := s.previousTotalCpuUsage[string(hostname)][string(taskID)]; !ok {
 					// First time fetching metrics for task. Recording taskID and hostname to help consolidation.
-					taskCpuUsage = &entities.Task{
-						Metric:   sampleStream.Metric,
-						Weight:   0.0,
-						ID:       string(taskID),
-						Hostname: string(hostname),
+					taskTotalCpuUsage = &taskCpuUsageInfo{
+						task: &entities.Task{
+							Metric:   sample.Metric,
+							Weight:   0.0,
+							ID:       string(taskID),
+							Hostname: string(hostname),
+						},
+						prevTotalCpuUsageTask: nil,
 					}
 
-					colocatedTasksCpuUsageSeconds[taskIDValueT(taskID)] = taskCpuUsage
-				}
-
-				if _, ok = sampleStream.Metric[cpuLabelName]; ok {
-					// Calculating and recording the cpu utilization (%) of this task on this cpu.
-					// Adding it to an accumulator that will later be used as the cpu utilization of
-					// this task across all cpus.
-					taskCpuUsage.Weight += s.cpuUtil(sampleStream.Values)
+					s.previousTotalCpuUsage[string(hostname)][string(taskID)] = taskTotalCpuUsage
+					// Recording cumulative cpu usage seconds for task on cpu.
+					nowTotalCpuUsage[string(hostname)][string(taskID)] = float64(sample.Value)
 				} else {
-					// CPU usage data does not correspond to a particular cpu.
-					// TODO do not ignore this. We should instead log this.
+					// Adding cumulative cpu usage seconds for task on a cpu.
+					nowTotalCpuUsage[string(hostname)][string(taskID)] += float64(sample.Value)
 				}
+			} else {
+				// Either taskID not exported along with the metrics, or
+				// Task ID dedicated label provided is incorrect.
+				// TODO do not ignore this. We should log this instead.
 			}
 		} else {
 			// Either hostname not exported along with the metrics, or
@@ -140,10 +146,19 @@ func (s *TaskRankCpuUtilStrategy) Execute(data model.Value) {
 	// Rank colocated tasks in non-increasing order based on their total cpu utilization (%)
 	// on the entire host (all cpus).
 	rankedTasks := make(entities.RankedTasks)
-	for hostname, colocatedTasksCpuUsageSeconds := range allTasksCpuUsageSeconds {
-		for _, taskCpuUsage := range colocatedTasksCpuUsageSeconds {
-			taskCpuUsage.Weight = s.round(taskCpuUsage.Weight)
-			rankedTasks[entities.Hostname(hostname)] = append(rankedTasks[entities.Hostname(hostname)], *taskCpuUsage)
+	for hostname, colocatedTasksCpuUsageInfo := range s.previousTotalCpuUsage {
+		for taskID, totalCpuUsage := range colocatedTasksCpuUsageInfo {
+			curTotalCpuUsageTask := nowTotalCpuUsage[hostname][taskID]
+			if totalCpuUsage.prevTotalCpuUsageTask != nil {
+				// Calculating the cpu utilization of this task.
+				totalCpuUsage.task.Weight = s.round(s.cpuUtil(*totalCpuUsage.prevTotalCpuUsageTask, curTotalCpuUsageTask))
+				rankedTasks[entities.Hostname(hostname)] = append(rankedTasks[entities.Hostname(hostname)], *totalCpuUsage.task)
+				totalCpuUsage.prevTotalCpuUsageTask = &curTotalCpuUsageTask
+			} else {
+				// We only have a single data point for task.
+				// Saving it for future use.
+				totalCpuUsage.prevTotalCpuUsageTask = &curTotalCpuUsageTask
+			}
 		}
 
 		// Sorting colocated tasks.
@@ -154,7 +169,9 @@ func (s *TaskRankCpuUtilStrategy) Execute(data model.Value) {
 	}
 
 	// Submitting ranked tasks to the receiver.
-	s.receiver.Receive(rankedTasks)
+	if len(rankedTasks) > 0 {
+		s.receiver.Receive(rankedTasks)
+	}
 }
 
 // cpuUtilPrecision defines the precision for cpu utilization (%) values.
@@ -169,12 +186,9 @@ func (s TaskRankCpuUtilStrategy) round(cpuUtil float64) float64 {
 }
 
 // cpuUtil calculates and returns the cpu utilization (%) for the task.
-// Elapsed time is calculated as the number of seconds between oldest and newest value by
-// factoring in the prometheus scrape interval.
-func (s TaskRankCpuUtilStrategy) cpuUtil(values []model.SamplePair) float64 {
-	n := len(values)
-	return 100.0 * ((float64(values[n-1].Value) - float64(values[0].Value)) /
-		(float64(n-1) * s.prometheusScrapeInterval.Seconds()))
+// Prometheus scrape interval is used as the elapsed time.
+func (s TaskRankCpuUtilStrategy) cpuUtil(prevTotalCpuUsage float64, nowTotalCpuUsage float64) float64 {
+	return 100.0 * ((nowTotalCpuUsage - prevTotalCpuUsage) / s.prometheusScrapeInterval.Seconds())
 }
 
 // GetMetric returns the name of the metric to query.
@@ -218,19 +232,8 @@ func (s TaskRankCpuUtilStrategy) GetLabelMatchers() []*query.LabelMatcher {
 // GetRange returns the time unit and duration for how far back (in seconds) values need to be fetched.
 func (s TaskRankCpuUtilStrategy) GetRange() (query.TimeUnit, uint) {
 	return s.rangeTimeUnit, s.rangeQty
-	// return query.Seconds, uint(5 * int(s.prometheusScrapeInterval.Seconds()))
 }
 
 // SetRange sets the time duration for the range query.
-// For cpu-util ranking strategy the time duration has to be > 1s as you need two data points to calculate cpu utilization.
-// If the provided time duration <= 1s, the default duration of 5 intervals of time is used, where each
-// interval of time is equal to the prometheus scrape interval.
-func (s *TaskRankCpuUtilStrategy) SetRange(timeUnit query.TimeUnit, qty uint) {
-	if !timeUnit.IsValid() || ((timeUnit == query.Seconds) && qty <= 1) {
-		s.rangeTimeUnit = query.Seconds
-		s.rangeQty = uint(5 * int(s.prometheusScrapeInterval.Seconds()))
-	} else {
-		s.rangeTimeUnit = timeUnit
-		s.rangeQty = qty
-	}
-}
+// As this strategy does not use range queries a call to this method results in a NO-OP.
+func (s *TaskRankCpuUtilStrategy) SetRange(_ query.TimeUnit, _ uint) {}

--- a/strategies/taskRankCpuUtilStrategy_test.go
+++ b/strategies/taskRankCpuUtilStrategy_test.go
@@ -99,7 +99,8 @@ func mockConstCpuUtilData(dedicatedLabelTaskID, dedicatedLabelTaskHost model.Lab
 				dedicatedLabelTaskHost: "localhost",
 				"cpu":                  "cpu00",
 			},
-			Value: model.SampleValue(0.225 * (elapsedTime + 1)),
+			Value:     model.SampleValue(0.225 * (elapsedTime + 1)),
+			Timestamp: model.Time(1000 * (elapsedTime + 1)),
 		},
 		{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -107,7 +108,8 @@ func mockConstCpuUtilData(dedicatedLabelTaskID, dedicatedLabelTaskHost model.Lab
 				dedicatedLabelTaskHost: "localhost",
 				"cpu":                  "cpu01",
 			},
-			Value: model.SampleValue(0.225 * (elapsedTime + 1)),
+			Value:     model.SampleValue(0.225 * (elapsedTime + 1)),
+			Timestamp: model.Time(1000 * (elapsedTime + 1)),
 		},
 		{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -115,7 +117,8 @@ func mockConstCpuUtilData(dedicatedLabelTaskID, dedicatedLabelTaskHost model.Lab
 				dedicatedLabelTaskHost: "localhost",
 				"cpu":                  "cpu00",
 			},
-			Value: model.SampleValue(0.3 * (elapsedTime + 1)),
+			Value:     model.SampleValue(0.3 * (elapsedTime + 1)),
+			Timestamp: model.Time(1000 * (elapsedTime + 1)),
 		},
 		{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -123,7 +126,8 @@ func mockConstCpuUtilData(dedicatedLabelTaskID, dedicatedLabelTaskHost model.Lab
 				dedicatedLabelTaskHost: "localhost",
 				"cpu":                  "cpu01",
 			},
-			Value: model.SampleValue(0.3 * (elapsedTime + 1)),
+			Value:     model.SampleValue(0.3 * (elapsedTime + 1)),
+			Timestamp: model.Time(1000 * (elapsedTime + 1)),
 		},
 		{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -131,7 +135,8 @@ func mockConstCpuUtilData(dedicatedLabelTaskID, dedicatedLabelTaskHost model.Lab
 				dedicatedLabelTaskHost: "localhost",
 				"cpu":                  "cpu00",
 			},
-			Value: model.SampleValue(0.675 * (elapsedTime + 1)),
+			Value:     model.SampleValue(0.675 * (elapsedTime + 1)),
+			Timestamp: model.Time(1000 * (elapsedTime + 1)),
 		},
 		{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -139,7 +144,8 @@ func mockConstCpuUtilData(dedicatedLabelTaskID, dedicatedLabelTaskHost model.Lab
 				dedicatedLabelTaskHost: "localhost",
 				"cpu":                  "cpu01",
 			},
-			Value: model.SampleValue(0.675 * (elapsedTime + 1)),
+			Value:     model.SampleValue(0.675 * (elapsedTime + 1)),
+			Timestamp: model.Time(1000 * (elapsedTime + 1)),
 		},
 	})
 	elapsedTime++
@@ -167,7 +173,8 @@ func mockVaryingCpuUtilData(dedicatedLabelTaskID, dedicatedLabelTaskHost model.L
 				dedicatedLabelTaskHost: "localhost",
 				"cpu":                  availableCpus[rand.Intn(2)],
 			},
-			Value: model.SampleValue(0.45 * (elapsedTime + 1)),
+			Value:     model.SampleValue(0.45 * (elapsedTime + 1)),
+			Timestamp: model.Time(1000 * (elapsedTime + 1)),
 		},
 		{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -175,7 +182,8 @@ func mockVaryingCpuUtilData(dedicatedLabelTaskID, dedicatedLabelTaskHost model.L
 				dedicatedLabelTaskHost: "localhost",
 				"cpu":                  availableCpus[rand.Intn(2)],
 			},
-			Value: model.SampleValue(0.6 * (elapsedTime + 1)),
+			Value:     model.SampleValue(0.6 * (elapsedTime + 1)),
+			Timestamp: model.Time(1000 * (elapsedTime + 1)),
 		},
 		{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -183,7 +191,8 @@ func mockVaryingCpuUtilData(dedicatedLabelTaskID, dedicatedLabelTaskHost model.L
 				dedicatedLabelTaskHost: "localhost",
 				"cpu":                  "cpu00",
 			},
-			Value: model.SampleValue(0.9 * (elapsedTime + 1)),
+			Value:     model.SampleValue(0.9 * (elapsedTime + 1)),
+			Timestamp: model.Time(1000 * (elapsedTime + 1)),
 		},
 		{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -191,7 +200,8 @@ func mockVaryingCpuUtilData(dedicatedLabelTaskID, dedicatedLabelTaskHost model.L
 				dedicatedLabelTaskHost: "localhost",
 				"cpu":                  "cpu01",
 			},
-			Value: model.SampleValue(0.45 * (elapsedTime + 1)),
+			Value:     model.SampleValue(0.45 * (elapsedTime + 1)),
+			Timestamp: model.Time(1000 * (elapsedTime + 1)),
 		},
 	})
 	elapsedTime++

--- a/strategies/taskRankCpuUtilStrategy_test.go
+++ b/strategies/taskRankCpuUtilStrategy_test.go
@@ -69,8 +69,8 @@ func TestTaskRankCpuUtilStrategy_GetRange(t *testing.T) {
 
 	checkRange := func(strategy *TaskRankCpuUtilStrategy) {
 		timeUnit, qty := strategy.GetRange()
-		assert.Equal(t, query.Seconds, timeUnit)
-		assert.Equal(t, uint(5), qty)
+		assert.Equal(t, query.None, timeUnit)
+		assert.Equal(t, uint(0), qty)
 	}
 
 	count := 5
@@ -81,30 +81,25 @@ func TestTaskRankCpuUtilStrategy_GetRange(t *testing.T) {
 	}
 }
 
-// mockCpuUtilData returns a mock of prometheus time series data.
+var elapsedTime float64 = 0
+
+// mockConstCpuUtilData returns a mock of prometheus time series data.
 // This mock has the following information.
 // 1. Three tasks with ids 'test_task_id_{1..3}'.
 // 2. Hostname for all tasks is localhost.
 // 3. For each task, cpu usage data is provided for two cpus, 'cpu00' and 'cpu01'.
-// 4. task with id 'test_task_id_1' shows cpu utilization of 22.5% on each cpu.
-// 5. task with id 'test_task_id_2' shows cpu utilization of 30% on each cpu.
-// 6. task with id 'test_task_id_3' shows cpu utilization of 67.5% on each cpu.
-func mockCpuUtilData(dedicatedLabelTaskID, dedicatedLabelTaskHost model.LabelName) model.Value {
-	now := time.Now()
-	return model.Value(model.Matrix{
+// 4. task with id 'test_task_id_1' demonstrates cpu utilization of 22.5% on each cpu.
+// 5. task with id 'test_task_id_2' demonstrates cpu utilization of 30% on each cpu.
+// 6. task with id 'test_task_id_3' demonstrates cpu utilization of 67.5% on each cpu.
+func mockConstCpuUtilData(dedicatedLabelTaskID, dedicatedLabelTaskHost model.LabelName) (mockedCpuUtilData model.Value) {
+	mockedCpuUtilData = model.Value(model.Vector{
 		{
 			Metric: map[model.LabelName]model.LabelValue{
 				dedicatedLabelTaskID:   "test_task_id_1",
 				dedicatedLabelTaskHost: "localhost",
 				"cpu":                  "cpu00",
 			},
-			Values: []model.SamplePair{
-				{Timestamp: model.Time(now.Unix()), Value: 0.5},
-				{Timestamp: model.Time(now.Add(1 * time.Second).Unix()), Value: 0.8},
-				{Timestamp: model.Time(now.Add(2 * time.Second).Unix()), Value: 1.1},
-				{Timestamp: model.Time(now.Add(3 * time.Second).Unix()), Value: 1.3},
-				{Timestamp: model.Time(now.Add(4 * time.Second).Unix()), Value: 1.4},
-			},
+			Value: model.SampleValue(0.225 * (elapsedTime + 1)),
 		},
 		{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -112,13 +107,7 @@ func mockCpuUtilData(dedicatedLabelTaskID, dedicatedLabelTaskHost model.LabelNam
 				dedicatedLabelTaskHost: "localhost",
 				"cpu":                  "cpu01",
 			},
-			Values: []model.SamplePair{
-				{Timestamp: model.Time(now.Unix()), Value: 0.5},
-				{Timestamp: model.Time(now.Add(1 * time.Second).Unix()), Value: 0.8},
-				{Timestamp: model.Time(now.Add(2 * time.Second).Unix()), Value: 1.1},
-				{Timestamp: model.Time(now.Add(3 * time.Second).Unix()), Value: 1.3},
-				{Timestamp: model.Time(now.Add(4 * time.Second).Unix()), Value: 1.4},
-			},
+			Value: model.SampleValue(0.225 * (elapsedTime + 1)),
 		},
 		{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -126,13 +115,7 @@ func mockCpuUtilData(dedicatedLabelTaskID, dedicatedLabelTaskHost model.LabelNam
 				dedicatedLabelTaskHost: "localhost",
 				"cpu":                  "cpu00",
 			},
-			Values: []model.SamplePair{
-				{Timestamp: model.Time(now.Unix()), Value: 0.5},
-				{Timestamp: model.Time(now.Add(1 * time.Second).Unix()), Value: 0.9},
-				{Timestamp: model.Time(now.Add(2 * time.Second).Unix()), Value: 1.3},
-				{Timestamp: model.Time(now.Add(3 * time.Second).Unix()), Value: 1.5},
-				{Timestamp: model.Time(now.Add(4 * time.Second).Unix()), Value: 1.7},
-			},
+			Value: model.SampleValue(0.3 * (elapsedTime + 1)),
 		},
 		{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -140,13 +123,7 @@ func mockCpuUtilData(dedicatedLabelTaskID, dedicatedLabelTaskHost model.LabelNam
 				dedicatedLabelTaskHost: "localhost",
 				"cpu":                  "cpu01",
 			},
-			Values: []model.SamplePair{
-				{Timestamp: model.Time(now.Unix()), Value: 0.5},
-				{Timestamp: model.Time(now.Add(1 * time.Second).Unix()), Value: 0.9},
-				{Timestamp: model.Time(now.Add(2 * time.Second).Unix()), Value: 1.3},
-				{Timestamp: model.Time(now.Add(3 * time.Second).Unix()), Value: 1.5},
-				{Timestamp: model.Time(now.Add(4 * time.Second).Unix()), Value: 1.7},
-			},
+			Value: model.SampleValue(0.3 * (elapsedTime + 1)),
 		},
 		{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -154,13 +131,7 @@ func mockCpuUtilData(dedicatedLabelTaskID, dedicatedLabelTaskHost model.LabelNam
 				dedicatedLabelTaskHost: "localhost",
 				"cpu":                  "cpu00",
 			},
-			Values: []model.SamplePair{
-				{Timestamp: model.Time(now.Unix()), Value: 0.3},
-				{Timestamp: model.Time(now.Add(1 * time.Second).Unix()), Value: 0.9},
-				{Timestamp: model.Time(now.Add(2 * time.Second).Unix()), Value: 1.6},
-				{Timestamp: model.Time(now.Add(3 * time.Second).Unix()), Value: 2.5},
-				{Timestamp: model.Time(now.Add(4 * time.Second).Unix()), Value: 3.0},
-			},
+			Value: model.SampleValue(0.675 * (elapsedTime + 1)),
 		},
 		{
 			Metric: map[model.LabelName]model.LabelValue{
@@ -168,15 +139,63 @@ func mockCpuUtilData(dedicatedLabelTaskID, dedicatedLabelTaskHost model.LabelNam
 				dedicatedLabelTaskHost: "localhost",
 				"cpu":                  "cpu01",
 			},
-			Values: []model.SamplePair{
-				{Timestamp: model.Time(now.Unix()), Value: 0.3},
-				{Timestamp: model.Time(now.Add(1 * time.Second).Unix()), Value: 0.9},
-				{Timestamp: model.Time(now.Add(2 * time.Second).Unix()), Value: 1.6},
-				{Timestamp: model.Time(now.Add(3 * time.Second).Unix()), Value: 2.5},
-				{Timestamp: model.Time(now.Add(4 * time.Second).Unix()), Value: 3.0},
-			},
+			Value: model.SampleValue(0.675 * (elapsedTime + 1)),
 		},
 	})
+	elapsedTime++
+	return
+}
+
+var availableCpus = map[int]model.LabelValue{
+	0: "cpu00",
+	1: "cpu01",
+}
+
+// mockVaryingCpuUtilData returns a mock of prometheus time series data.
+// This mock has the following information.
+// 1. Three tasks with ids 'test_task_id_{1..3}'.
+// 2. Hostname for all tasks is localhost.
+// 3. For each task, cpu usage data is provided for a subset of the two cpus, 'cpu00' and 'cpu01'.
+// 4. task with id 'test_task_id_1' demonstrates total cpu utilization of 45%.
+// 5. task with id 'test_task_id_2' demonstrates total cpu utilization of 60%.
+// 6. task with id 'test_task_id_3' demonstrates total cpu utilization of 135%.
+func mockVaryingCpuUtilData(dedicatedLabelTaskID, dedicatedLabelTaskHost model.LabelName) (mockedCpuUtilData model.Value) {
+	mockedCpuUtilData = model.Value(model.Vector{
+		{
+			Metric: map[model.LabelName]model.LabelValue{
+				dedicatedLabelTaskID:   "test_task_id_1",
+				dedicatedLabelTaskHost: "localhost",
+				"cpu":                  availableCpus[rand.Intn(2)],
+			},
+			Value: model.SampleValue(0.45 * (elapsedTime + 1)),
+		},
+		{
+			Metric: map[model.LabelName]model.LabelValue{
+				dedicatedLabelTaskID:   "test_task_id_2",
+				dedicatedLabelTaskHost: "localhost",
+				"cpu":                  availableCpus[rand.Intn(2)],
+			},
+			Value: model.SampleValue(0.6 * (elapsedTime + 1)),
+		},
+		{
+			Metric: map[model.LabelName]model.LabelValue{
+				dedicatedLabelTaskID:   "test_task_id_3",
+				dedicatedLabelTaskHost: "localhost",
+				"cpu":                  "cpu00",
+			},
+			Value: model.SampleValue(0.9 * (elapsedTime + 1)),
+		},
+		{
+			Metric: map[model.LabelName]model.LabelValue{
+				dedicatedLabelTaskID:   "test_task_id_3",
+				dedicatedLabelTaskHost: "localhost",
+				"cpu":                  "cpu01",
+			},
+			Value: model.SampleValue(0.45 * (elapsedTime + 1)),
+		},
+	})
+	elapsedTime++
+	return
 }
 
 func TestTaskRankCpuUtilStrategy_Execute(t *testing.T) {
@@ -193,9 +212,6 @@ func TestTaskRankCpuUtilStrategy_Execute(t *testing.T) {
 	}
 	s.Init()
 
-	data := mockCpuUtilData("container_label_task_id", "container_label_task_host")
-	s.Execute(data)
-
 	expectedRankedTasks := map[entities.Hostname][]entities.Task{
 		"localhost": {
 			{
@@ -206,7 +222,8 @@ func TestTaskRankCpuUtilStrategy_Execute(t *testing.T) {
 				},
 				ID:       "test_task_id_3",
 				Hostname: "localhost",
-				Weight:   135.0, // sum of cpu util (%) on cpu00 and cpu01.
+				// Expected sum of cpu util (%) on cpu00 and cpu01.
+				Weight: 135.0,
 			},
 			{
 				Metric: map[model.LabelName]model.LabelValue{
@@ -216,7 +233,8 @@ func TestTaskRankCpuUtilStrategy_Execute(t *testing.T) {
 				},
 				ID:       "test_task_id_2",
 				Hostname: "localhost",
-				Weight:   60.0, // sum of cpu util (%) on cpu00 and cpu01.
+				// Expected sum of cpu util (%) on cpu00 and cpu01.
+				Weight: 60.0,
 			},
 			{
 				Metric: map[model.LabelName]model.LabelValue{
@@ -226,16 +244,47 @@ func TestTaskRankCpuUtilStrategy_Execute(t *testing.T) {
 				},
 				ID:       "test_task_id_1",
 				Hostname: "localhost",
-				Weight:   45.0, // sum of cpu util (%) on cpu00 and cpu01.
+				// Expected sum of cpu util (%) on cpu00 and cpu01.
+				Weight: 45.0,
 			},
 		},
 	}
 
-	assert.Equal(t, len(expectedRankedTasks), len(receiver.rankedTasks))
+	t.Run("tasks demonstrate constant cpu usage and use all cpus", func(t *testing.T) {
+		for i := 0; i < 5; i++ {
+			data := mockConstCpuUtilData("container_label_task_id", "container_label_task_host")
+			s.Execute(data)
 
-	_, ok := expectedRankedTasks["localhost"]
-	_, localhostIsInRankedTasks := receiver.rankedTasks["localhost"]
-	assert.True(t, ok == localhostIsInRankedTasks)
+			if i == 0 {
+				// No ranked tasks yet as we only have one second of data.
+				assert.Empty(t, receiver.rankedTasks)
+				continue
+			}
 
-	assert.ElementsMatch(t, expectedRankedTasks["localhost"], receiver.rankedTasks["localhost"])
+			assert.Equal(t, len(expectedRankedTasks), len(receiver.rankedTasks))
+
+			_, ok := expectedRankedTasks["localhost"]
+			_, localhostIsInRankedTasks := receiver.rankedTasks["localhost"]
+			assert.True(t, ok == localhostIsInRankedTasks)
+
+			assert.ElementsMatch(t, expectedRankedTasks["localhost"], receiver.rankedTasks["localhost"])
+		}
+
+	})
+
+	t.Run("tasks demonstrate varying cpu usage and do not run on all cpus", func(t *testing.T) {
+		for i := 0; i < 5; i++ { // Starting from 5 to simulate cumulative cpu usage from previous test.
+			data := mockVaryingCpuUtilData("container_label_task_id", "container_label_task_host")
+			s.Execute(data)
+
+			assert.Equal(t, len(expectedRankedTasks), len(receiver.rankedTasks))
+
+			_, ok := expectedRankedTasks["localhost"]
+			_, localhostIsInRankedTasks := receiver.rankedTasks["localhost"]
+			assert.True(t, ok == localhostIsInRankedTasks)
+
+			assert.ElementsMatch(t, expectedRankedTasks["localhost"], receiver.rankedTasks["localhost"])
+		}
+
+	})
 }


### PR DESCRIPTION
Unless tasks are pinned to cpus, there is no guarantee that data be
received for that task on that cpu. Therefore, we now add up the
cumulative cpu usage seconds on all cpus and then compute the cpu
utilization using the change in cpu usage in the next time interval.

With this change, task ranker is now stateful as cpuutil task ranking
strategy stores the previous values of cumulative cpu time.

Updated test code to now test cpuutil task ranking strategy in
different scenarios - contant cpu utilization + varying cpu utilization
and tasks not using all cpus in each interval.

Updated readme to not use cpuutil task ranking strategy when showing
how Strategy initialization options can be used for configuration.