### PR TITLE
bugfix: schedule validation with second granularity.

### DIFF
--- a/ranker.go
+++ b/ranker.go
@@ -63,7 +63,7 @@ func New(options ...Option) (*TaskRanker, error) {
 	}
 
 	// validate task ranker schedule to be a multiple of prometheus scrape interval.
-	now := time.Unix(50000, 50000)
+	now := time.Unix(0, 0)
 	nextTimeTRankerSchedule := tRanker.Schedule.Next(now)
 	tRankerScheduleIntervalSeconds := int(nextTimeTRankerSchedule.Sub(now).Seconds())
 	if (tRankerScheduleIntervalSeconds < int(tRanker.prometheusScrapeInterval.Seconds())) ||


### PR DESCRIPTION
github.com/robfig/cron/v3 supports only second granularity when
computing Next(...). Therefore, if we initialize current time to be
half a second after 1970 Jan 1 (time.Unix(50000, 50000)), then
schedule.Next(now) would give us 0 if the schedule is every second.

Fixed the initialization of the current time to be exactly 1970 Jan 1
(time.Unix(0, 0)) so that task ranker can be run every second.

Added test coverage to check the following two scenarios.
1. task ranker schedule = 0.
2. task ranker schedule = 1 = prometheus scrape interval.