### PR TITLE
Bugfix/cpuutil strategy segfault

### DIFF
--- a/query/builder.go
+++ b/query/builder.go
@@ -27,7 +27,6 @@ type Builder struct {
 	// List of labels to be used to filter the data. This is an optional field.
 	labelMatchers []*LabelMatcher
 	// The unit of time to use when performing range queries. This is an optional field.
-	// If this field is not initialized, then
 	timeUnit     TimeUnit
 	timeDuration uint
 	// TODO (pradykaushik) support functions.

--- a/strategies/strategy_test.go
+++ b/strategies/strategy_test.go
@@ -1,0 +1,19 @@
+package strategies
+
+import (
+	"github.com/pradykaushik/task-ranker/logger"
+	"log"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	err := logger.Configure()
+	if err != nil {
+		log.Println("could not configure logger for strategy testing")
+	}
+	m.Run()
+	err = logger.Done()
+	if err != nil {
+		log.Println("could not close logger after strategy testing")
+	}
+}

--- a/strategies/strategy_test.go
+++ b/strategies/strategy_test.go
@@ -1,3 +1,16 @@
+// Copyright 2020 Pradyumna Kaushik
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package strategies
 
 import (

--- a/strategies/taskRankCpuSharesStrategy_test.go
+++ b/strategies/taskRankCpuSharesStrategy_test.go
@@ -15,7 +15,6 @@ package strategies
 
 import (
 	"github.com/pradykaushik/task-ranker/entities"
-	"github.com/pradykaushik/task-ranker/logger"
 	"github.com/pradykaushik/task-ranker/query"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
@@ -101,8 +100,6 @@ func TestTaskRankCpuSharesStrategy_Execute(t *testing.T) {
 		dedicatedLabelNameTaskHostname: model.LabelName("container_label_task_host"),
 	}
 	s.Init()
-	// Configuring logger.
-	assert.Nil(t, logger.Configure())
 
 	data := mockCpuSharesData("container_label_task_id", "container_label_task_host")
 	s.Execute(data)
@@ -146,6 +143,4 @@ func TestTaskRankCpuSharesStrategy_Execute(t *testing.T) {
 	assert.True(t, ok == localhostIsInRankedTasks)
 
 	assert.ElementsMatch(t, expectedRankedTasks["localhost"], receiver.rankedTasks["localhost"])
-
-	// logger will be closed after the last test in this package.
 }

--- a/strategies/taskRankCpuSharesStrategy_test.go
+++ b/strategies/taskRankCpuSharesStrategy_test.go
@@ -79,35 +79,14 @@ func TestTaskRankCpuSharesStrategy_GetRange(t *testing.T) {
 // 5. task with id 'test_task_id_3' is allocated a 3072 cpu shares.
 func mockCpuSharesData(dedicatedLabelTaskID, dedicatedLabelTaskHost model.LabelName) model.Value {
 	now := time.Now()
-	return model.Value(model.Matrix{
-		{
-			Metric: map[model.LabelName]model.LabelValue{
-				dedicatedLabelTaskID:   "test_task_id_1",
-				dedicatedLabelTaskHost: "localhost",
-			},
-			Values: []model.SamplePair{
-				{Timestamp: model.Time(now.Second()), Value: 1024.0},
-			},
-		},
-		{
-			Metric: map[model.LabelName]model.LabelValue{
-				dedicatedLabelTaskID:   "test_task_id_2",
-				dedicatedLabelTaskHost: "localhost",
-			},
-			Values: []model.SamplePair{
-				{Timestamp: model.Time(now.Second()), Value: 2048.0},
-			},
-		},
-		{
-			Metric: map[model.LabelName]model.LabelValue{
-				dedicatedLabelTaskID:   "test_task_id_3",
-				dedicatedLabelTaskHost: "localhost",
-			},
-			Values: []model.SamplePair{
-				{Timestamp: model.Time(now.Second()), Value: 3072.0},
-			},
-		},
-	})
+	return model.Matrix{
+		getMockDataRange(dedicatedLabelTaskID, dedicatedLabelTaskHost, uniqueTaskSets[0][0],
+			hostname, model.SamplePair{Timestamp: model.Time(now.Second()), Value: 1024.0}),
+		getMockDataRange(dedicatedLabelTaskID, dedicatedLabelTaskHost, uniqueTaskSets[0][1],
+			hostname, model.SamplePair{Timestamp: model.Time(now.Second()), Value: 2048.0}),
+		getMockDataRange(dedicatedLabelTaskID, dedicatedLabelTaskHost, uniqueTaskSets[0][2],
+			hostname, model.SamplePair{Timestamp: model.Time(now.Second()), Value: 3072.0}),
+	}
 }
 
 func TestTaskRankCpuSharesStrategy_Execute(t *testing.T) {

--- a/strategies/taskRankCpuSharesStrategy_test.go
+++ b/strategies/taskRankCpuSharesStrategy_test.go
@@ -15,6 +15,7 @@ package strategies
 
 import (
 	"github.com/pradykaushik/task-ranker/entities"
+	"github.com/pradykaushik/task-ranker/logger"
 	"github.com/pradykaushik/task-ranker/query"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
@@ -121,6 +122,8 @@ func TestTaskRankCpuSharesStrategy_Execute(t *testing.T) {
 		dedicatedLabelNameTaskHostname: model.LabelName("container_label_task_host"),
 	}
 	s.Init()
+	// Configuring logger.
+	assert.Nil(t, logger.Configure())
 
 	data := mockCpuSharesData("container_label_task_id", "container_label_task_host")
 	s.Execute(data)
@@ -164,4 +167,6 @@ func TestTaskRankCpuSharesStrategy_Execute(t *testing.T) {
 	assert.True(t, ok == localhostIsInRankedTasks)
 
 	assert.ElementsMatch(t, expectedRankedTasks["localhost"], receiver.rankedTasks["localhost"])
+
+	// logger will be closed after the last test in this package.
 }

--- a/strategies/taskRankCpuUtilStrategy.go
+++ b/strategies/taskRankCpuUtilStrategy.go
@@ -171,32 +171,31 @@ func (s *TaskRankCpuUtilStrategy) Execute(data model.Value) {
 		}
 	}
 
-	// Rank colocated tasks in non-increasing order based on their total cpu utilization (%)
-	// on the entire host (all cpus).
-
-	// TODO (pradykaushik) Change below code to work with cpu usage information received now. This will reduce #iterations.
+	// Rank colocated tasks in non-increasing order based on their total cpu utilization (%) on the entire host (all cpus).
 	// TODO (pradykaushik) Periodically drain previousTotalCpuUsage to prevent it from growing indefinitely.
 	rankedTasks := make(entities.RankedTasks)
-	for hostname, colocatedTasksCpuUsageInfo := range s.previousTotalCpuUsage {
-		for taskID, prevTotalCpuUsage := range colocatedTasksCpuUsageInfo {
-			if prevTotalCpuUsage.dataPoint == nil {
-				prevTotalCpuUsage.dataPoint = new(cpuUsageDataPoint)
+	for hostname, cpuUsageColocatedActiveTasks := range nowTotalCpuUsage {
+		for taskID, totalCpuUsageInfoActiveTask := range cpuUsageColocatedActiveTasks {
+			// calculating cpu utilization if cpu usage information previously recorded.
+			prevRecordedTotalCpuUsage := s.previousTotalCpuUsage[hostname][taskID]
+			if prevRecordedTotalCpuUsage.dataPoint == nil {
+				prevRecordedTotalCpuUsage.dataPoint = new(cpuUsageDataPoint)
 			} else {
-				// Calculating the cpu utilization of this task.
-				prevTotalCpuUsage.task.Weight = s.round(s.cpuUtil(
-					prevTotalCpuUsage.dataPoint.totalCumulativeCpuUsage,
-					prevTotalCpuUsage.dataPoint.timestamp,
-					nowTotalCpuUsage[hostname][taskID].totalCumulativeCpuUsage,
-					nowTotalCpuUsage[hostname][taskID].timestamp,
+				prevRecordedTotalCpuUsage.task.Weight = s.round(s.cpuUtil(
+					prevRecordedTotalCpuUsage.dataPoint.totalCumulativeCpuUsage,
+					prevRecordedTotalCpuUsage.dataPoint.timestamp,
+					totalCpuUsageInfoActiveTask.totalCumulativeCpuUsage,
+					totalCpuUsageInfoActiveTask.timestamp,
 				))
-				rankedTasks[entities.Hostname(hostname)] = append(rankedTasks[entities.Hostname(hostname)], *prevTotalCpuUsage.task)
+				rankedTasks[entities.Hostname(hostname)] = append(rankedTasks[entities.Hostname(hostname)],
+					*prevRecordedTotalCpuUsage.task)
 			}
 			// Saving current total cumulative cpu usage seconds to calculate cpu utilization in the next interval.
-			prevTotalCpuUsage.dataPoint.totalCumulativeCpuUsage = nowTotalCpuUsage[hostname][taskID].totalCumulativeCpuUsage
-			prevTotalCpuUsage.dataPoint.timestamp = nowTotalCpuUsage[hostname][taskID].timestamp
+			prevRecordedTotalCpuUsage.dataPoint.totalCumulativeCpuUsage = totalCpuUsageInfoActiveTask.totalCumulativeCpuUsage
+			prevRecordedTotalCpuUsage.dataPoint.timestamp = totalCpuUsageInfoActiveTask.timestamp
 		}
 
-		// Sorting colocated tasks.
+		// Sorting co-located tasks.
 		sort.SliceStable(rankedTasks[entities.Hostname(hostname)], func(i, j int) bool {
 			return rankedTasks[entities.Hostname(hostname)][i].Weight >=
 				rankedTasks[entities.Hostname(hostname)][j].Weight

--- a/strategies/taskRankCpuUtilStrategy.go
+++ b/strategies/taskRankCpuUtilStrategy.go
@@ -52,6 +52,7 @@ type TaskRankCpuUtilStrategy struct {
 	// On the other hand, if the tasks are not pinned, then there is no guarantee that the necessary number of data points be available
 	// as the cpu scheduler can preempt and re-schedule the task on any available cpu.
 	// Therefore, to avoid confusion, this strategy does not use the range query.
+	// TODO (pkaushi1) get rid of this eventually.
 	rangeTimeUnit query.TimeUnit
 	rangeQty      uint
 }
@@ -113,7 +114,7 @@ func (s *TaskRankCpuUtilStrategy) Execute(data model.Value) {
 	}
 
 	var ok bool
-	// nowTotalCpuUsage stores the total cumulative cpu usage for each running task.
+	// Stores the total cumulative cpu usage for each running task.
 	var nowTotalCpuUsage = make(map[string]map[string]*cpuUsageDataPoint)
 
 	// Parse Prometheus metrics.
@@ -172,6 +173,9 @@ func (s *TaskRankCpuUtilStrategy) Execute(data model.Value) {
 
 	// Rank colocated tasks in non-increasing order based on their total cpu utilization (%)
 	// on the entire host (all cpus).
+
+	// TODO (pradykaushik) Change below code to work with cpu usage information received now. This will reduce #iterations.
+	// TODO (pradykaushik) Periodically drain previousTotalCpuUsage to prevent it from growing indefinitely.
 	rankedTasks := make(entities.RankedTasks)
 	for hostname, colocatedTasksCpuUsageInfo := range s.previousTotalCpuUsage {
 		for taskID, prevTotalCpuUsage := range colocatedTasksCpuUsageInfo {

--- a/strategies/taskRankCpuUtilStrategy_test.go
+++ b/strategies/taskRankCpuUtilStrategy_test.go
@@ -82,41 +82,6 @@ func TestTaskRankCpuUtilStrategy_GetRange(t *testing.T) {
 	}
 }
 
-var elapsedTimeSeconds float64 = 0
-
-const hostname model.LabelValue = "localhost"
-
-// Task IDs to create mocks.
-var uniqueTaskSets = map[int][]model.LabelValue{
-	0: {"test_task_id_1", "test_task_id_2", "test_task_id_3"},
-	1: {"test_task_id_4", "test_task_id_5", "test_task_id_6"},
-	2: {"test_task_id_7", "test_task_id_8", "test_task_id_9"},
-}
-
-var availableCpus = map[int]model.LabelValue{
-	0: "cpu00",
-	1: "cpu01",
-}
-
-// getMockDataSample returns a data sample mimicking cpu_usage_seconds information
-// retrieved for a single task from prometheus.
-func getMockDataSample(
-	dedicatedLabelTaskID, dedicatedLabelTaskHost model.LabelName,
-	taskID, hostname, cpu model.LabelValue,
-	cumulativeCpuUsageSeconds float64,
-	timestamp float64) *model.Sample {
-
-	return &model.Sample{
-		Metric: map[model.LabelName]model.LabelValue{
-			dedicatedLabelTaskID: taskID,
-			dedicatedLabelTaskHost: hostname,
-			"cpu": cpu,
-		},
-		Value: model.SampleValue(cumulativeCpuUsageSeconds),
-		Timestamp: model.Time(timestamp),
-	}
-}
-
 // mockCpuUtilDataAlwaysUsingAllCpus returns a mock of prometheus time series data.
 // This mock is useful to test scenarios where tasks are N-level parallel (N >= #cpus) and use up all the cpus all the time.
 //
@@ -130,17 +95,17 @@ func getMockDataSample(
 func mockCpuUtilDataAlwaysUsingAllCpus(dedicatedLabelTaskID, dedicatedLabelTaskHost model.LabelName) (mockedCpuUtilData model.Value) {
 	mockedCpuUtilData = model.Vector{
 		getMockDataSample(dedicatedLabelTaskID, dedicatedLabelTaskHost, uniqueTaskSets[0][0], hostname, availableCpus[0],
-			0.225 * (elapsedTimeSeconds + 1), 1000 * (elapsedTimeSeconds + 1)),
+			0.225*(elapsedTimeSeconds+1), 1000*(elapsedTimeSeconds+1)),
 		getMockDataSample(dedicatedLabelTaskID, dedicatedLabelTaskHost, uniqueTaskSets[0][0], hostname, availableCpus[1],
-			0.225 * (elapsedTimeSeconds + 1), 1000 * (elapsedTimeSeconds + 1)),
+			0.225*(elapsedTimeSeconds+1), 1000*(elapsedTimeSeconds+1)),
 		getMockDataSample(dedicatedLabelTaskID, dedicatedLabelTaskHost, uniqueTaskSets[0][1], hostname, availableCpus[0],
-			0.3 * (elapsedTimeSeconds + 1), 1000 * (elapsedTimeSeconds + 1)),
+			0.3*(elapsedTimeSeconds+1), 1000*(elapsedTimeSeconds+1)),
 		getMockDataSample(dedicatedLabelTaskID, dedicatedLabelTaskHost, uniqueTaskSets[0][1], hostname, availableCpus[1],
-			0.3 * (elapsedTimeSeconds + 1), 1000 * (elapsedTimeSeconds + 1)),
+			0.3*(elapsedTimeSeconds+1), 1000*(elapsedTimeSeconds+1)),
 		getMockDataSample(dedicatedLabelTaskID, dedicatedLabelTaskHost, uniqueTaskSets[0][2], hostname, availableCpus[0],
-			0.675 * (elapsedTimeSeconds + 1), 1000 * (elapsedTimeSeconds + 1)),
+			0.675*(elapsedTimeSeconds+1), 1000*(elapsedTimeSeconds+1)),
 		getMockDataSample(dedicatedLabelTaskID, dedicatedLabelTaskHost, uniqueTaskSets[0][2], hostname, availableCpus[1],
-			0.675 * (elapsedTimeSeconds + 1), 1000 * (elapsedTimeSeconds + 1)),
+			0.675*(elapsedTimeSeconds+1), 1000*(elapsedTimeSeconds+1)),
 	}
 	elapsedTimeSeconds++
 	return
@@ -160,13 +125,13 @@ func mockCpuUtilDataAlwaysUsingAllCpus(dedicatedLabelTaskID, dedicatedLabelTaskH
 func mockCpuUtilDataUsingOnlySomeCpus(dedicatedLabelTaskID, dedicatedLabelTaskHost model.LabelName) (mockedCpuUtilData model.Value) {
 	mockedCpuUtilData = model.Vector{
 		getMockDataSample(dedicatedLabelTaskID, dedicatedLabelTaskHost, uniqueTaskSets[0][0], hostname, availableCpus[0],
-			0.45 * (elapsedTimeSeconds + 1), 1000 * (elapsedTimeSeconds + 1)),
+			0.45*(elapsedTimeSeconds+1), 1000*(elapsedTimeSeconds+1)),
 		getMockDataSample(dedicatedLabelTaskID, dedicatedLabelTaskHost, uniqueTaskSets[0][1], hostname, availableCpus[0],
-			0.6 * (elapsedTimeSeconds + 1), 1000 * (elapsedTimeSeconds + 1)),
+			0.6*(elapsedTimeSeconds+1), 1000*(elapsedTimeSeconds+1)),
 		getMockDataSample(dedicatedLabelTaskID, dedicatedLabelTaskHost, uniqueTaskSets[0][2], hostname, availableCpus[0],
-			0.9 * (elapsedTimeSeconds + 1), 1000 * (elapsedTimeSeconds + 1)),
+			0.9*(elapsedTimeSeconds+1), 1000*(elapsedTimeSeconds+1)),
 		getMockDataSample(dedicatedLabelTaskID, dedicatedLabelTaskHost, uniqueTaskSets[0][2], hostname, availableCpus[1],
-			0.45 * (elapsedTimeSeconds + 1), 1000 * (elapsedTimeSeconds + 1)),
+			0.45*(elapsedTimeSeconds+1), 1000*(elapsedTimeSeconds+1)),
 	}
 	elapsedTimeSeconds++
 	return

--- a/strategies/taskRankCpuUtilStrategy_test.go
+++ b/strategies/taskRankCpuUtilStrategy_test.go
@@ -15,7 +15,6 @@ package strategies
 
 import (
 	"github.com/pradykaushik/task-ranker/entities"
-	"github.com/pradykaushik/task-ranker/logger"
 	"github.com/pradykaushik/task-ranker/query"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
@@ -154,7 +153,6 @@ func TestTaskRankCpuUtilStrategy_Execute(t *testing.T) {
 		prometheusScrapeInterval:       1 * time.Second,
 	}
 	s.Init()
-	// logger is already configured in the first test in this package.
 
 	expectedRankedTasks := map[entities.Hostname][]entities.Task{
 		"localhost": {
@@ -465,6 +463,4 @@ func TestTaskRankCpuUtilStrategy_Execute(t *testing.T) {
 
 		assert.ElementsMatch(t, expectedRankedTasks["localhost"], receiver.rankedTasks["localhost"])
 	})
-
-	assert.Nil(t, logger.Done())
 }

--- a/strategies/testutil.go
+++ b/strategies/testutil.go
@@ -1,0 +1,54 @@
+package strategies
+
+import "github.com/prometheus/common/model"
+
+var elapsedTimeSeconds float64 = 0
+
+const hostname model.LabelValue = "localhost"
+
+// Task IDs to create mocks.
+var uniqueTaskSets = map[int][]model.LabelValue{
+	0: {"test_task_id_1", "test_task_id_2", "test_task_id_3"},
+	1: {"test_task_id_4", "test_task_id_5", "test_task_id_6"},
+	2: {"test_task_id_7", "test_task_id_8", "test_task_id_9"},
+}
+
+var availableCpus = map[int]model.LabelValue{
+	0: "cpu00",
+	1: "cpu01",
+}
+
+// getMockDataSample returns a data sample mimicking cpu_usage_seconds information
+// retrieved from prometheus for a single task.
+func getMockDataSample(
+	dedicatedLabelTaskID, dedicatedLabelTaskHost model.LabelName,
+	taskID, hostname, cpu model.LabelValue,
+	cumulativeCpuUsageSeconds float64,
+	timestamp float64) *model.Sample {
+
+	return &model.Sample{
+		Metric: map[model.LabelName]model.LabelValue{
+			dedicatedLabelTaskID:   taskID,
+			dedicatedLabelTaskHost: hostname,
+			"cpu":                  cpu,
+		},
+		Value:     model.SampleValue(cumulativeCpuUsageSeconds),
+		Timestamp: model.Time(timestamp),
+	}
+}
+
+// getMockDataRange returns a data sample stream mimicking cpu_usage_seconds information
+// retrieved as a result of a range query from prometheus for a single task.
+func getMockDataRange(
+	dedicatedLabelTaskID, dedicatedLabelTaskHost model.LabelName,
+	taskID, hostname model.LabelValue,
+	values ...model.SamplePair) *model.SampleStream {
+
+	return &model.SampleStream{
+		Metric: map[model.LabelName]model.LabelValue{
+			dedicatedLabelTaskID:   taskID,
+			dedicatedLabelTaskHost: hostname,
+		},
+		Values: values,
+	}
+}

--- a/strategies/testutil.go
+++ b/strategies/testutil.go
@@ -1,3 +1,16 @@
+// Copyright 2020 Pradyumna Kaushik
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package strategies
 
 import "github.com/prometheus/common/model"


### PR DESCRIPTION
Added additional tests for cpu-util strategy testing.
1. Test when there is no cpu usage data.
2. Test when the cpu usage information is available for a different set of tasks compared to the previous fetch.